### PR TITLE
Remove chardet import

### DIFF
--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -7,7 +7,6 @@ from concurrent.futures import CancelledError
 
 import aiohttp
 import async_timeout
-import chardet
 from azure.servicebus.aio import ServiceBusClient
 from azure.servicebus.exceptions import ServiceBusError
 


### PR DESCRIPTION
Does not seem like it is being used, and it is not included by default in HA, and is missing from manifest.json