### PR TITLE
Fix error "Platform zaptec does not generate unique IDs."

### DIFF
--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -446,11 +446,18 @@ class Account:
 
         self.installs = cls_installs
 
+        # Will also report chargers listed in installation hierarchy above
         so_chargers = await self.chargers()
+        added_chargers = []
         for charger in so_chargers:
             if charger.id not in self.map:
                 self.map[charger.id] = charger
-        self.stand_alone_chargers = so_chargers
+
+                # Our charger is not listed in the hierarchy above this add
+                # this as a stand-alone
+                added_chargers.append(charger)
+
+        self.stand_alone_chargers = added_chargers
 
 class Charger(ZapBase):
     def __init__(self, data, account):


### PR DESCRIPTION
The Zaptec API reports back all chargers when requesting the list of chargers, including those that are a part of an installation. At the same time, the integration adds the chargers when it has been added through the traversal of the installation -> circuit. In order to prevent double sensor registration error in HA, the chargers that are a part of an installation hierarchy should not be added as stand-alone charger. This PR fix that and it will fix #26 