### PR TITLE
Added missing azure-servicebus requirement

### DIFF
--- a/custom_components/zaptec/manifest.json
+++ b/custom_components/zaptec/manifest.json
@@ -7,6 +7,6 @@
   "codeowners": [
     "hellowlol"
   ],
-  "requirements": [],
+  "requirements": ["azure-servicebus"],
   "version": "0.0.6b2"
 }


### PR DESCRIPTION
The zaptec integration is missing declaration of it needing the `azure-servicebus` python package.

I believe this fixes #33 and #34