### PR TITLE
Fix issues with crash when unloading or disabling zaptec

### DIFF
--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -71,24 +71,13 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Set up zaptec as config entry."""
     await _dry_setup(hass, entry.data)
-
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Unload a config entry."""
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, component)
-                for component in PLATFORMS
-            ]
-        )
-    )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
         acc = hass.data[DOMAIN]["api"]

--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -238,6 +238,8 @@ class Installation(ZapBase):
             receiver = servicebus_client.get_subscription_receiver(
                 topic_name=conf["Topic"], subscription_name=conf["Subscription"]
             )
+            # Store the receiver in order to close it and cancel this stream
+            self._receiver = receiver
             async with receiver:
                 async for msg in receiver:
                     await asyncio.sleep(0)
@@ -295,6 +297,7 @@ class Installation(ZapBase):
     async def cancel_stream(self):
         if self._stream_task is not None:
             try:
+                await self._receiver.close()
                 self._stream_task.cancel()
                 await self._stream_task
                 _LOGGER.debug("Canceled stream")


### PR DESCRIPTION
Unloading the zaptec integration will create a trace-back in the logs, see #44. This PR proposes a fix for it. 

The `_stream()` task was blocking the cleanup which is the root cause for the crash. The fix sends a `close()` to the azure-stream object and then cancels the stream task. That seems to work fine in my installation.
