### PR TITLE
Fix set charge current

### DIFF
--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -171,7 +171,7 @@ class Installation(ZapBase):
         data = await self._account.installation(self.id)
         self.set_attributes(data)
 
-    async def limit_amps(self, **kwargs):
+    async def limit_current(self, **kwargs):
         """Set a limit now how many amps the installation can use
 
         Use availableCurrent for 3phase
@@ -186,9 +186,12 @@ class Installation(ZapBase):
             "availableCurrentPhase3",
         ]
 
-        keys = list(kwargs.keys())
-        if any(k for k in keys for i in phases) and total in keys:
-            kwargs.pop("availableCurrent")
+        # If any of the phases are present and not None, remove the total field.
+        if any(k and v is not None
+               for k, v in kwargs.items()
+               if k in phases
+               ):
+            kwargs.pop(total, None)
 
         return await self._account._request(
             f"installation/{self.id}/update", method="post", data=kwargs
@@ -394,23 +397,24 @@ class Account:
             "Accept": "application/json",
         }
         full_url = API_URL + url
-        if method == "post":
-            header["Accept"] = "Application/patch-json+json"
         try:
             with async_timeout.timeout(30):
                 call = getattr(self._client, method)
                 if data is not None and method == "post":
-                    call = partial(call, data=data)
+                    call = partial(call, json=data)
                 async with call(full_url, headers=header) as resp:
-                    if resp.status == 401:
+                    if resp.status == 401:  # Unauthorized
                         await self._refresh_token()
                         return await self._request(url)
-                    elif resp.status == 204:
+                    elif resp.status == 204:  # No content
                         content = await resp.read()
                         return content
-                    else:
+                    elif resp.status == 200:  # OK
                         json_result = await resp.json(content_type=None)
                         return json_result
+                    else:
+                        _LOGGER.error("Could not get info from %s: %s", full_url, resp)
+                        return None
 
         except (asyncio.TimeoutError, aiohttp.ClientError) as err:
             _LOGGER.error("Could not get info from %s: %s", full_url, err)

--- a/custom_components/zaptec/services.yaml
+++ b/custom_components/zaptec/services.yaml
@@ -40,12 +40,16 @@ restart_charger:
       description: "The charger id"
       example: "yyyyyyyy-9999-99xx-xxxx-yyyyyyyyyyyy"
 
-limit_amps:
-  description: "Update installation properties for 3 phases."
+limit_current:
+  description: "Update available current for the installation."
   fields:
     installation_id:
+      required: true
       description: "The installation id"
       example: "yyyyyyyy-9999-99xx-xxxx-yyyyyyyyyyyy"
+    available_current:
+      description: "The available current for all phases. Cannot be used together with any available_current_phase* fields"
+      example: "16"
     available_current_phase1:
       description: "The available current for phase 1"
       example: "16"
@@ -54,7 +58,4 @@ limit_amps:
       example: "16"
     available_current_phase3:
       description: "The available current for phase 3"
-      example: "16"
-    available_current:
-      description: "The available currents"
       example: "16"


### PR DESCRIPTION
In current master service request for setting current is still not working. There are two main reasons for that: The POST call to the API doesn't do the right datatype for the API. Secondly the logic for handling the `availableCurrent` parameter isn't working and it sends the wrong POST data.

This PR fixes these issues, and as such it supersedes PR #35 which can be closed. I've based it on your proposal/PR @gustafssone. Thank you. I didn't indent to steal your thunder, so I hope this PR is ok.

* Fix API POST call issue
* Rename 'limit_amps' to 'limit_current'
* Rename methods accordingly
* Added user message and validation for 1 and 3 phase
* Fix bug in 1 vs 3 phase current selection

PS! I took the liberty to rename all methods from `limit_amps` to `limit_current`. I find that to be more formally correct English and it bugged me enough that I changed it.

*edit* I forgot to mention that I've tested this on a 3-phase Zaptec Go installation and I've verified that both setting all phases at once, and setting each phase to different values work.