### PR TITLE
Add support for debug API data dump

### DIFF
--- a/custom_components/zaptec/misc.py
+++ b/custom_components/zaptec/misc.py
@@ -9,3 +9,79 @@ def to_under(word) -> str:
     word = re.sub(r"([a-z\d])([A-Z])", r"\1_\2", word)
     word = word.replace("-", "_")
     return word.lower()
+
+
+class Redactor:
+    """ Class to handle redaction of sensitive data. """
+
+    # Data fields that must be redacted from the output
+    REDACT_KEYS = [
+        "Address", "City", "Latitude", "Longitude", "ZipCode",
+        "Pin", "SerialNo",
+        "Id", "CircuitId", "DeviceId", "InstallationId", "MID", "ChargerId",
+        "Name", "InstallationName",
+        "SignedMeterValueKwh", "SignedMeterValue",
+    ]
+
+    # Keys that will be looked up into the observer id dict
+    OBS_KEYS = [
+        "SettingId", "StateId"
+    ]
+
+    # State or settings ids that must be redacted
+    REDACT_IDS = [
+        "100",  # ???
+        "554",  # SignedMeterValue
+        "723",  # CompletedSession
+        "750",  # NewChargeCard
+        "952",  # MacWiFi
+        "960",  # LteImsi
+        "962",  # LteIccid
+        "963",  # LteImei
+    ]
+
+    def __init__(self, redacted, acc):
+        self.redacted = redacted
+        self.acc = acc
+        self.redacts = {}
+
+    def redact(self, text, make_new=False):
+        ''' Redact the text if it is present in the redacted dict.
+            A new redaction is created if make_new is True
+        '''
+        if not self.redacted:
+            return text
+        elif text in self.redacts:
+            return self.redacts[text]
+        elif make_new:
+            red = f"<--Redact #{(len(self.redacts) + 1):02d}-->"
+            self.redacts[text] = red
+            return red
+        return text
+
+    def redact_ids_inplace(self, obj):
+        need_redact = any(str(obj.get(k)) in self.REDACT_IDS for k in self.OBS_KEYS)
+        for k, v in obj.items():
+            if k in self.OBS_KEYS and v in self.acc.obs:
+                v = f"{v} {self.acc.obs[v]}"
+            if need_redact and 'value' in k.lower():
+                v = self.redact(v, make_new=True)
+            obj[k] = v
+
+    def redact_obj_inplace(self, obj, mode=None):
+        ''' Iterate over obj and redact the fields. NOTE! This function
+            modifies the argument object in-place.
+        '''
+        if isinstance(obj, list):
+            for k in obj:
+                self.redact_obj_inplace(k, mode=mode)
+            return
+        elif not isinstance(obj, dict):
+            return
+        if mode == 'ids':
+            self.redact_ids_inplace(obj)
+        for k, v in obj.items():
+            if isinstance(v, (list, dict)):
+                self.redact_obj_inplace(v, mode=mode)
+                continue
+            obj[k] = self.redact(v, make_new=k in self.REDACT_KEYS)

--- a/custom_components/zaptec/services.yaml
+++ b/custom_components/zaptec/services.yaml
@@ -59,3 +59,10 @@ limit_current:
     available_current_phase3:
       description: "The available current for phase 3"
       example: "16"
+
+debug_data_dump:
+  description: "Dump RAW data from the zaptec API."
+  fields:
+    redacted:
+      required: false
+      description: "Redact sensitive data"


### PR DESCRIPTION
Very often when developing there is a need to inspect the data produced by the Zaptec API. It might often be helpful to be able to inspect the data from other users with different setups. However one should be careful to share the raw API data as it contains sensitive data.

This PR propose:

- Add `zaptec.debug_data_dump` service
- Run the dump from `python api.py` command-line
- Optional data redaction to remove sensitive data from output

The output generated by the API data dump contains sensitive data. In order to allow sharing of API data with others, but not leak sensitive data, a redaction functionality is implemented. It is not perfect so the output should always be checked before public share.

The service has an bool option `redacted` which will select if the output is redacted or not. It is by default 'true'. The service generates a file on the HA server which can be downloaded from the HA URL `<HA_URL>/local/zaptec/api_data.txt`. HA might need to be restarted for it serve the file.

Here is an example of a redacted dump file: https://gist.github.com/sveinse/6b59a2b4236cd2ccf561646e889465d6

I know this proposal is a bit sidetrack for the main purpose of the integration. However, I've experienced enough need to "see the data" to work on the development. I hope this can be useful, but I'll understand if this isn't that interesting to add to the mainline code.