### PR TITLE
Fix #85 and #87

### DIFF
--- a/custom_components/zaptec/sensor.py
+++ b/custom_components/zaptec/sensor.py
@@ -232,7 +232,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         device_class=SensorDeviceClass.ENERGY,
         icon="mdi:counter",
         native_unit_of_measurement=const.UnitOfEnergy.KILO_WATT_HOUR,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     ZapSensorEntityDescription(
         key="humidity",

--- a/custom_components/zaptec/sensor.py
+++ b/custom_components/zaptec/sensor.py
@@ -248,7 +248,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         translation_key="temperature_internal5",
         device_class=SensorDeviceClass.TEMPERATURE,
         icon="mdi:temperature-celsius",
-        native_unit_of_measurement=const.TEMP_CELSIUS,
+        native_unit_of_measurement=const.UnitOfTemperature.CELSIUS,
         entity_category=const.EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
     ),


### PR DESCRIPTION
Use const.UnitOfTemperature.CELSIUS instead of const.TEMP_CELSIUS since it's deprecated.
Use SensorStateClass.TOTAL_INCREASING instead of SensorStateClass.MEASUREMENT since that is not supported for SensorDeviceClass.ENERGY.