### PR TITLE
Fix stale devices (#89) and total (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.7.2b1
 
+* Delete old stale devices, #89
+* Changed "total_charger_power_session" to TOTAL, #87
 * Added new installation sensors "Installation type", "Network type"
 * Added new charger sensor "Device type"
 * Added new service call "send_command" for sending any commands to the

--- a/custom_components/zaptec/sensor.py
+++ b/custom_components/zaptec/sensor.py
@@ -216,7 +216,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         device_class=SensorDeviceClass.ENERGY,
         icon="mdi:counter",
         native_unit_of_measurement=const.UnitOfEnergy.KILO_WATT_HOUR,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.TOTAL,
     ),
     ZapSensorEntityDescription(
         key="signed_meter_value_kwh",
@@ -232,7 +232,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         device_class=SensorDeviceClass.ENERGY,
         icon="mdi:counter",
         native_unit_of_measurement=const.UnitOfEnergy.KILO_WATT_HOUR,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.TOTAL,
     ),
     ZapSensorEntityDescription(
         key="humidity",

--- a/custom_components/zaptec/zconst.py
+++ b/custom_components/zaptec/zconst.py
@@ -148,5 +148,5 @@ class ZConst(UserDict):
         val = int(v)
         if not val:
             return "None"
-        roles = set(k for k, v in self.get("UserRoles", {}).items() if v & val)
+        roles = set(k for k, v in self.get("UserRoles", {}).items() if v & val == v)
         return ", ".join(roles)


### PR DESCRIPTION
Small fix address the `TOTAL` issue of entities "total_charge_power_session" and "completed_session.Energy" which does not work well with HA when they decrease their value. Fixes #87 (was a remaining tail).

Fix stale devices that might be left from older versions of this integration. Fixes #89 