### PR TITLE
Add binary sensor for online charger (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.2b1
 
+* Add "online" binary entity in charger, #114
 * Reduce the amount of logging from the API, #90
 * Delete old stale devices, #89
 * Changed "total_charger_power_session" to TOTAL, #87

--- a/custom_components/zaptec/binary_sensor.py
+++ b/custom_components/zaptec/binary_sensor.py
@@ -63,7 +63,7 @@ INSTALLATION_ENTITIES: list[EntityDescription] = [
         name="Installation",  # Special case, no translation
         device_class=BinarySensorDeviceClass.CONNECTIVITY,  # False=disconnected, True=connected
         entity_category=const.EntityCategory.DIAGNOSTIC,
-        icon="mdi:home-lightning-bolt-outline",
+        icon="mdi:cloud",
         has_entity_name=False,
         cls=ZaptecBinarySensorWithAttrs,
     ),
@@ -84,7 +84,7 @@ CIRCUIT_ENTITIES: list[EntityDescription] = [
         name="Circuit",  # Special case, no translation
         device_class=BinarySensorDeviceClass.CONNECTIVITY,  # False=disconnected, True=connected
         entity_category=const.EntityCategory.DIAGNOSTIC,
-        icon="mdi:orbit",
+        icon="mdi:cloud",
         has_entity_name=False,
         cls=ZaptecBinarySensorWithAttrs,
     ),
@@ -96,9 +96,17 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         name="Charger",  # Special case, no translation
         device_class=BinarySensorDeviceClass.CONNECTIVITY,  # False=disconnected, True=connected
         entity_category=const.EntityCategory.DIAGNOSTIC,
-        icon="mdi:ev-station",
+        icon="mdi:cloud",
         has_entity_name=False,
         cls=ZaptecBinarySensorWithAttrs,
+    ),
+    ZapBinarySensorEntityDescription(
+        key="is_online",
+        translation_key="online",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,  # False=disconnected, True=connected
+        entity_category=const.EntityCategory.DIAGNOSTIC,
+        icon="mdi:ev-station",
+        cls=ZaptecBinarySensor,
     ),
     ZapBinarySensorEntityDescription(
         key="is_authorization_required",

--- a/custom_components/zaptec/translations/en.json
+++ b/custom_components/zaptec/translations/en.json
@@ -69,6 +69,7 @@
                     "on": "Required"
                 }
             },
+            "online": { "name": "Online" },
             "permanent_cable_lock": { "name": "Permanent cable lock" }
         },
         "button": {


### PR DESCRIPTION
This PR adds "Online" to the Charger device which tracks the Zaptec "is_online" attribute. Fixes #114 