### PR TITLE
Add missing translations to entities with state

### DIFF
--- a/custom_components/zaptec/translations/en.json
+++ b/custom_components/zaptec/translations/en.json
@@ -32,22 +32,61 @@
     },
     "entity": {
         "sensor": {
-            "authentication_type": { "name": "Authentication type" },
+            "authentication_type": { 
+                "name": "Authentication type",
+                "state": {
+                    "Native": "Native",
+                    "WebHooks": "Web Hooks",
+                    "Ocpp": "OCPP"
+                }
+            },
             "available_current_phase1": { "name": "Available current phase 1" },
             "available_current_phase2": { "name": "Available current phase 2" },
             "available_current_phase3": { "name": "Available current phase 3" },
             "charge_current_set": { "name": "Allocated charge current" },
-            "charger_operation_mode": { "name": "Charger operation mode" },
+            "charger_operation_mode": {
+                "name": "Charger operation mode",
+                "state": {
+                    "Unknown": "Uknown",
+                    "Disconnected": "Disconnected",
+                    "Connected_Requesting": "Connected (Requesting)",
+                    "Connected_Charging": "Charging",
+                    "Connected_Finished": "Finished"
+                }
+            },
             "completed_session_energy": { "name": "Completed session energy" },
             "current_phase1": { "name": "Current phase 1" },
             "current_phase2": { "name": "Current phase 2" },
             "current_phase3": { "name": "Current phase 3" },
-            "device_type": { "name": "Device type" },
+            "device_type": {
+                "name": "Device type",
+                "state": {
+                    "Unknown": "Unknown"
+                }
+            },
             "humidity": { "name": "Humidity" },
             "installation_type": { "name": "Installation type" },
             "max_current": { "name": "Max current" },
-            "network_type": { "name": "Network type" },
-            "operating_mode": { "name": "Charger mode" },
+            "network_type": { 
+                "name": "Network type",
+                "state": {
+                    "Unknown": "Uknown",
+                    "IT_1_Phase": "IT 1 Phase",
+                    "IT_3_Phase": "IT 3 Phase",
+                    "TN_1_Phase": "TN 1 Phase",
+                    "TN_3_Phase": "TN 3 Phase"
+                }
+            },
+            "operating_mode": {
+                "name": "Charger mode",
+                "state": {
+                    "Unknown": "Uknown",
+                    "Disconnected": "Disconnected",
+                    "Connected_Requesting": "Connected (Requesting)",
+                    "Connected_Charging": "Charging",
+                    "Connected_Finished": "Finished"
+                }
+            },
             "signed_meter_value": { "name": "Energy meter"},
             "temperature_internal5": { "name": "Temperature (internal)" },
             "total_charge_power_session": { "name": "Session total charge" },

--- a/custom_components/zaptec/translations/en.json
+++ b/custom_components/zaptec/translations/en.json
@@ -47,7 +47,7 @@
             "charger_operation_mode": {
                 "name": "Charger operation mode",
                 "state": {
-                    "Unknown": "Uknown",
+                    "Unknown": "Unknown",
                     "Disconnected": "Disconnected",
                     "Connected_Requesting": "Connected (Requesting)",
                     "Connected_Charging": "Charging",
@@ -70,7 +70,7 @@
             "network_type": { 
                 "name": "Network type",
                 "state": {
-                    "Unknown": "Uknown",
+                    "Unknown": "Unknown",
                     "IT_1_Phase": "IT 1 Phase",
                     "IT_3_Phase": "IT 3 Phase",
                     "TN_1_Phase": "TN 1 Phase",
@@ -80,11 +80,11 @@
             "operating_mode": {
                 "name": "Charger mode",
                 "state": {
-                    "Unknown": "Uknown",
+                    "Unknown": "Unknown",
                     "Disconnected": "Disconnected",
-                    "Connected_Requesting": "Connected (Requesting)",
-                    "Connected_Charging": "Charging",
-                    "Connected_Finished": "Finished"
+                    "Waiting": "Waiting",
+                    "Charging": "Charging",
+                    "Charge done": "Charge done"
                 }
             },
             "signed_meter_value": { "name": "Energy meter"},


### PR DESCRIPTION
Adds English translations for entities with states which is read from Zaptec cloud. The entities are "operating_mode", "authentication_type" and more.

Related to #117 