### PR TITLE
Total -> Total Increasing

### DIFF
--- a/custom_components/zaptec/sensor.py
+++ b/custom_components/zaptec/sensor.py
@@ -216,7 +216,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         device_class=SensorDeviceClass.ENERGY,
         icon="mdi:counter",
         native_unit_of_measurement=const.UnitOfEnergy.KILO_WATT_HOUR,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     ZapSensorEntityDescription(
         key="signed_meter_value_kwh",
@@ -232,7 +232,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         device_class=SensorDeviceClass.ENERGY,
         icon="mdi:counter",
         native_unit_of_measurement=const.UnitOfEnergy.KILO_WATT_HOUR,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     ZapSensorEntityDescription(
         key="humidity",


### PR DESCRIPTION
As I understand the documentation at https://developers.home-assistant.io/blog/2021/08/16/state_class_total/ and https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes these sensors should be TOTAL_INCREASING as they're decreasing at the end of the session.