### PR TITLE
Update dev container to latest HA-core

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Zaptec integration development",
-    "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.11-bullseye",
+    "image": "mcr.microsoft.com/vscode/devcontainers/python:3.13-bullseye",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [
         8123

--- a/custom_components/zaptec/manifest.json
+++ b/custom_components/zaptec/manifest.json
@@ -9,6 +9,6 @@
     "sveinse"
   ],
   "iot_class": "cloud_polling",
-  "requirements": ["azure-servicebus==7.13.0", "pydantic"],
+  "requirements": ["azure-servicebus==7.14.2", "pydantic"],
   "version": "0.7.4"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-colorlog==6.7.0
-homeassistant==2023.6.0
-pip>=21.0,<23.2
-ruff==0.0.267
+colorlog==6.9.0
+homeassistant==2025.6.3
+pip>=25.0,<25.2
+ruff==0.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ colorlog==6.9.0
 homeassistant==2025.6.3
 pip>=25.0,<25.2
 ruff==0.12.1
+bleak==0.22.3 # bleak 1.0.0 breaks habluetooth as of 2025.06.29, remove once https://github.com/Bluetooth-Devices/habluetooth/issues/248 is resolved

--- a/scripts/setup
+++ b/scripts/setup
@@ -12,6 +12,6 @@ pip_packages() {
         "${@}"
 }
 
-pip_packages "pip<23.2,>=21.3.1"
+pip_packages "pip<25.2,>=25.0.0"
 pip_packages setuptools wheel
 pip_packages --requirement requirements.txt


### PR DESCRIPTION
Update requirements to get a functional dev-container with the latest HA-core version
(ref discussion on  https://github.com/custom-components/zaptec/pull/183)