### PR TITLE
Do not send Pause/Resume to API if we know it will be rejected

### DIFF
--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -676,8 +676,7 @@ class Charger(ZaptecBase):
         if command not in ZCONST.commands and command != "authorize_charge":
             if raise_value_error_if_invalid:
                 raise ValueError(f"Unknown command '{command}'")
-            else:
-                return False
+            return False
 
         if isinstance(command, int):
             # If int, look up the command name
@@ -701,12 +700,11 @@ class Charger(ZaptecBase):
 
         if valid_command:
             return True
-        elif raise_value_error_if_invalid:
+        if raise_value_error_if_invalid:
             _LOGGER.warning(msg)
             _LOGGER.debug("operation_mode: %s, final_stop_active: %s", operation_mode, final_stop_active)
             raise ValueError(msg)
-        else:
-            return False
+        return False
 
     async def set_settings(self, settings: dict[str, Any]):
         """Set settings on the charger"""

--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -656,10 +656,7 @@ class Charger(ZaptecBase):
         if command == "authorize_charge":
             return await self.authorize_charge()
 
-        # Fetching the name from the ZCONST is perhaps not a good idea
-        # if Zaptec is changing them.
-        if command not in ZCONST.commands:
-            raise ValueError(f"Unknown command '{command}'")
+        self.is_command_valid(command, raise_value_error_if_invalid=True)
 
         if isinstance(command, int):
             # If int, look up the command name
@@ -673,6 +670,43 @@ class Charger(ZaptecBase):
             f"chargers/{self.id}/SendCommand/{cmdid}", method="post"
         )
         return data
+
+    def is_command_valid(self, command: str|int, raise_value_error_if_invalid=False) -> bool:
+        # Fetching the name from the ZCONST is perhaps not a good idea if Zaptec is changing them.
+        if command not in ZCONST.commands and command != "authorize_charge":
+            if raise_value_error_if_invalid:
+                raise ValueError(f"Unknown command '{command}'")
+            else:
+                return False
+
+        if isinstance(command, int):
+            # If int, look up the command name
+            command = ZCONST.commands.get(command)
+
+        valid_command = True
+        msg = ""
+        if command in ["resume_charging", "stop_charging_final"]:
+            # Pause/stop or resume charging are only allowed in certain states, see comments on
+            # commands 506+507 in https://api.zaptec.com/help/index.html#/Charger/Charger_SendCommand_POST
+            operation_mode = self.get("ChargerOperationMode")
+            final_stop_active = self.get("FinalStopActive")
+            paused = (operation_mode == "Connected_Finished" and int(final_stop_active) == 1)
+            if command == "stop_charging_final" and (paused or operation_mode == "Disconnected"):
+                msg = "Pause/stop charging is not allowed if charging is already paused or disconnected"
+                valid_command = False
+            elif command == "resume_charging" and not paused:
+                # should also check for NextScheduleEvent, but API doc is difficult to interpret
+                msg = "Resume charging is not allowed if charger is not paused"
+                valid_command = False
+
+        if valid_command:
+            return True
+        elif raise_value_error_if_invalid:
+            _LOGGER.warning(msg)
+            _LOGGER.debug("operation_mode: %s, final_stop_active: %s", operation_mode, final_stop_active)
+            raise ValueError(msg)
+        else:
+            return False
 
     async def set_settings(self, settings: dict[str, Any]):
         """Set settings on the charger"""

--- a/custom_components/zaptec/button.py
+++ b/custom_components/zaptec/button.py
@@ -26,6 +26,15 @@ _LOGGER = logging.getLogger(__name__)
 class ZaptecButton(ZaptecBaseEntity, ButtonEntity):
     zaptec_obj: Charger
 
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if not self._attr_available:
+            return False
+        else:
+            # Disable/gray out button if the command is invalid in the current state
+            return self.zaptec_obj.is_command_valid(self.key)
+
     async def async_press(self) -> None:
         """Press the button."""
         _LOGGER.debug(


### PR DESCRIPTION
The "Resume/Stop charging" buttons are disabled/grayed out when they cannot be used.

I tried doing the same for the "Charging"-switch, but it appears it just ignores the availability setting and triggers anyway. The is_command_valid check in the command-function will still block the API call if we are in a state where the command is not legal, and raising the exception triggers a popup in the UI for direct user feedback.