### PR TITLE
Cleanup: Rename class Account to Zaptec

### DIFF
--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -1092,7 +1092,7 @@ class Zaptec:
                 raise log_exc(error)
 
     # =======================================================================
-    #   API METHODS
+    #   UPDATE METHODS
 
     async def build(self):
         """Make the python interface."""

--- a/custom_components/zaptec/services.py
+++ b/custom_components/zaptec/services.py
@@ -190,7 +190,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             matches = set(
                 (coord, obj)
                 for coord in hass.data[DOMAIN].values()
-                for obj in coord.account.map.values()
+                for obj in coord.zaptec.map.values()
                 if obj.id == uid
             )
             # Filter out the objects that doesn't match the expected type


### PR DESCRIPTION
This PR contains the rename of `class Account` to `class Zaptec` to make it more descriptive and consistent. This is a part of a series of cleanups to improve the API for the Zaptec facing API.

**NOTE** This is technically a API change, but since the only consumers of the API are the HA integration, this should be fine. The PR does not contain any functional change.

* Rename members from self._account to self.zaptec in Installation and Charger objects
* Rename self.account in ZaptecFlowHandler
