### PR TITLE
Cleanup: Rename _request() to request()

### DIFF
--- a/custom_components/zaptec/diagnostics.py
+++ b/custom_components/zaptec/diagnostics.py
@@ -208,7 +208,7 @@ async def async_get_device_diagnostics(
 
         async def req(url):
             try:
-                result = await acc._request(url)
+                result = await zaptec.request(url)
                 if not isinstance(result, (dict, list)):
                     return {
                         "type error": f"Expected dict, got type {type(result).__name__}, value {result}",


### PR DESCRIPTION
This PR renames `Zaptec._request()`(or `Account._request()` to `Zaptec.request()`.

This PR must be merged after #196 

In addition this PR is a little experiment on stacking PRs. I'm hoping that the diff gets smaller once the other PR is merged. It's going to be interesting to see.