### PR TITLE
Main API cleanup. Breaking changes

### DIFF
--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -261,9 +261,8 @@ class Installation(ZaptecBase):
         for circuit in hierarchy["Circuits"]:
             _LOGGER.debug("    Circuit %s", circuit["Id"])
             for charger_item in circuit["Chargers"]:
-
                 # Inject additional attributes
-                charger_item["InstallationId"] = self.id  # So the relationship is ready at build
+                charger_item["InstallationId"] = self.id
                 charger_item["CircuitId"] = circuit["Id"]
                 charger_item["CircuitName"] = circuit["Name"]
                 charger_item["CircuitMaxCurrent"] = circuit["MaxCurrent"]

--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -144,9 +144,6 @@ class ZaptecBase(Mapping[str, TValue]):
     # =======================================================================
     #   UPDATE METHODS
 
-    async def build(self) -> None:
-        """Build the object."""
-
     async def state(self) -> None:
         """Update the state of the object."""
 
@@ -281,7 +278,6 @@ class Installation(ZaptecBase):
                     charger = Charger(charger_item, self.zaptec, installation=self)
                     self.zaptec.register(charger_item["Id"], charger)
 
-                await charger.build()
                 self.chargers.append(charger)
 
     async def state(self):
@@ -1191,7 +1187,7 @@ class Zaptec(Mapping[str, ZaptecBase]):
             _LOGGER.warning("To remove them, please restart the integration.")
         if extra_chargers := (new_chargers - have_chargers):
             _LOGGER.warning(
-                "These standalone chargers will not added: %s", extra_chargers
+                "These standalone chargers will not be added: %s", extra_chargers
             )
 
         # Update the observation, settings and commands ids based on the

--- a/custom_components/zaptec/config_flow.py
+++ b/custom_components/zaptec/config_flow.py
@@ -93,7 +93,7 @@ class ZaptecFlowHandler(ConfigFlow, domain=DOMAIN):
                     await self.zaptec.build()
 
                 # Get all chargers
-                chargers = self.zaptec.get_chargers()
+                chargers = list(self.zaptec.chargers)
 
         except (RequestConnectionError, RequestTimeoutError, RequestDataError):
             errors["base"] = "cannot_connect"
@@ -105,9 +105,9 @@ class ZaptecFlowHandler(ConfigFlow, domain=DOMAIN):
 
         def charger_text(charger: Charger):
             """Format the charger text for display."""
-            text = f"{charger.name} ({getattr(charger, 'device_id', '-')})"
-            if charger.circuit_name:
-                text += f" in {charger.circuit_name} circuit"
+            text = f"{charger.name} ({charger.get('device_id', '-')})"
+            if circuit := charger.get("circuit_name"):
+                text += f" in {circuit} circuit"
             if charger.installation:
                 text += f" of {charger.installation.name} installation"
             return text

--- a/custom_components/zaptec/diagnostics.py
+++ b/custom_components/zaptec/diagnostics.py
@@ -196,7 +196,7 @@ async def async_get_device_diagnostics(
     #  PRE SEED OBJECT IDS FOR REDACTION
     #
     try:
-        for id, obj in zaptec.map.items():
+        for id, obj in zaptec.items():
             red.add_redact(id, ctx="preseed", redact=f"<--{obj.qual_id}-->")
     except Exception as err:
         add_failure(out, err)
@@ -234,7 +234,7 @@ async def async_get_device_diagnostics(
             data = await req(url := f"installation/{inst_id}/hierarchy")
 
             for circuit in data.get("Circuits", []):
-                add(f"circuits/{circuit['Id']}", circuit, ctx="circuit")
+                add(f"circuits/{circuit["Id"]}", circuit, ctx="circuit")
                 for charger in circuit.get("Chargers", []):
                     charger_in_circuits_ids.append(charger["Id"])
 
@@ -273,7 +273,7 @@ async def async_get_device_diagnostics(
 
         out.setdefault(
             "maps",
-            [red.redact(addmap(k, v), ctx="maps") for k, v in zaptec.map.items()],
+            [red.redact(addmap(k, v), ctx="maps") for k, v in zaptec.items()],
         )
     except Exception as err:
         add_failure(out, err)
@@ -284,7 +284,7 @@ async def async_get_device_diagnostics(
     try:
 
         def add_key(k):
-            v = zaptec.map.get(k)
+            v = zaptec.get(k)
             if v is None:
                 return k
             return v.qual_id
@@ -342,14 +342,13 @@ if __name__ == "__main__":
     async def gogo():
         username = os.environ.get("zaptec_username")
         password = os.environ.get("zaptec_password")
-        zaptec = Zaptec(
-            username,
-            password,
-            client=aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)),
-        )
-        await zaptec.build()
 
-        try:
+        async with (
+            aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session,
+            Zaptec(username, password, client=session) as zaptec,
+        ):
+            await zaptec.build()
+
             #
             # Mocking to pretend to be a hass instance
             #
@@ -376,8 +375,5 @@ if __name__ == "__main__":
             # Get the diagnostics info
             out = await async_get_device_diagnostics(hass, config, None)
             pprint(out)
-
-        finally:
-            await zaptec._client.close()
 
     asyncio.run(gogo())

--- a/custom_components/zaptec/diagnostics.py
+++ b/custom_components/zaptec/diagnostics.py
@@ -234,7 +234,7 @@ async def async_get_device_diagnostics(
             data = await req(url := f"installation/{inst_id}/hierarchy")
 
             for circuit in data.get("Circuits", []):
-                add(f"circuits/{circuit["Id"]}", circuit, ctx="circuit")
+                add(f"circuits/{circuit['Id']}", circuit, ctx="circuit")
                 for charger in circuit.get("Chargers", []):
                     charger_in_circuits_ids.append(charger["Id"])
 

--- a/custom_components/zaptec/services.py
+++ b/custom_components/zaptec/services.py
@@ -190,7 +190,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             matches = set(
                 (coord, obj)
                 for coord in hass.data[DOMAIN].values()
-                for obj in coord.zaptec.map.values()
+                for obj in coord.zaptec.objects()
                 if obj.id == uid
             )
             # Filter out the objects that doesn't match the expected type


### PR DESCRIPTION
* class Zaptec
  * Make class Zaptec an async context in order to close the web session
  * Make the class a `Mapping` of (Zaptec) objects with dict-like interface.
  * Mapping changes must go via `register` and `unregister`.
  * `register` will fail on re-registeringing an existing object
  * Add `.objects()`, `.installations` and `chargers` as methods to fetch subset of data from the class
  * `.build()` can be called multiple times. If run again it will update the existing objects
  * Stop exposing `.map`
  * Remove `get_circuits_id()`. Its too specialized and is handled directly where its used.
  * `.get_chargers()` is not the property `.chargers`
  * `.installations` is now a property and not a variable
  * Add warnings on removal of or standalone chargers. We don't handle this yet.

* class ZaptecBase
  * Make class ZaptecBase a `Mapping` with a RO dict-like interface for parameters
  * Removed `.__getattr__()` so `obj.something` doesn't work. However `.id` and `.name` is explicitly kept.

* class Installation
  * Update `.build()` to support re-runs without creating new objects

* class Charger
  * Remove unused `.live()` method
  * Remove empty `.build()` method

* General
  * Cleanup and reorganization
  * Adopt the HA integration to the API changes