### PR TITLE
Refactor Zaptec integration to improve polling and command handling

### DIFF
--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -55,6 +55,8 @@ from .const import (
     MANUFACTURER,
     MISSING,
     REQUEST_REFRESH_DELAY,
+    ZAPTEC_POLL_CHARGER_TRIGGER_DELAYS,
+    ZAPTEC_POLL_INSTALLATION_TRIGGER_DELAYS,
 )
 from .services import async_setup_services, async_unload_services
 
@@ -133,7 +135,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Make a set of the circuit ids from zaptec to check for deprecated Circuit-devices
     circuit_ids = {
-        cid for c in coordinator.zaptec.chargers if (cid := c.get("circuit_id", ""))
+        cid for c in coordinator.zaptec.chargers if (cid := c.get("CircuitId"))
     }
 
     # Clean up unused device entries with no entities
@@ -193,6 +195,7 @@ class ZaptecUpdateCoordinator(DataUpdateCoordinator[None]):
         self.zaptec: Zaptec = zaptec
         self.streams: list[tuple[asyncio.Task, Installation]] = []
         self.entity_maps: dict[str, dict[str, ZaptecBaseEntity]] = {}
+        self.updateable_objects: set[str] = set()
 
         super().__init__(
             hass,
@@ -277,11 +280,13 @@ class ZaptecUpdateCoordinator(DataUpdateCoordinator[None]):
         if self.config_entry.data.get(CONF_MANUAL_SELECT, False):
             chargers = self.config_entry.data.get(CONF_CHARGERS)
 
+        all_objects = set(self.zaptec)
+        self.updateable_objects = all_objects
+
         # Selected chargers to add
         if chargers is not None:
             _LOGGER.debug("Configured chargers: %s", chargers)
             want = set(chargers)
-            all_objects = set(self.zaptec)
 
             # Log if there are any objects listed not found in Zaptec
             not_present = want - all_objects
@@ -300,11 +305,8 @@ class ZaptecUpdateCoordinator(DataUpdateCoordinator[None]):
             if not keep:
                 _LOGGER.error("No zaptec objects will be added")
 
-            # Unregister all discovered objects not in the keep list
-            for objid in all_objects:
-                if objid not in keep:
-                    _LOGGER.debug("Unregistering: %s", objid)
-                    self.zaptec.unregister(objid)
+            # These objects will be updated by the coordinator
+            self.updateable_objects = want
 
         # Setup the stream subscription
         self.create_streams()
@@ -323,13 +325,55 @@ class ZaptecUpdateCoordinator(DataUpdateCoordinator[None]):
 
                 # Fetch updates
                 _LOGGER.debug("Polling from Zaptec")
-                await self.zaptec.update_states()
+                await self.zaptec.poll(
+                    self.updateable_objects, state=True, info=True, firmware=True
+                )
 
         except ZaptecApiError as err:
             _LOGGER.exception(
                 "Fetching data failed: %s: %s", type(err).__qualname__, err
             )
             raise UpdateFailed(err) from err
+
+    async def _trigger_poll(self, obj: ZaptecBase) -> None:
+        """Trigger a poll update sequence for the given object or all objects.
+
+        This sequence is useful to ensure that the state is fully synced after a
+        HA initiated update.
+        """
+
+        what = {obj.id}
+        if isinstance(obj, Installation):
+            delay_list = ZAPTEC_POLL_INSTALLATION_TRIGGER_DELAYS
+            kw = {"state": True, "info": True}
+        else:
+            delay_list = ZAPTEC_POLL_CHARGER_TRIGGER_DELAYS
+            kw = {"state": True}
+
+        for i, delay in enumerate(delay_list, start=1):
+            await asyncio.sleep(delay)
+            _LOGGER.debug(
+                "Triggering poll %s of %s after %s seconds. %s",
+                i,
+                obj.qual_id,
+                delay,
+                kw,
+            )
+            await self.zaptec.poll(what, **kw)
+            self.async_update_listeners()
+
+    async def trigger_poll(self, obj: ZaptecBase) -> None:
+        """Trigger a poll update sequence."""
+
+        # FIXME: The current imeplementation will create a new background task
+        # no matter if a task is already running. If they are updating the same
+        # object, this can cause too many updates for the same object.
+        # A single task per device will be needed.
+        self.config_entry.async_create_background_task(
+            self.hass,
+            self._trigger_poll(obj),
+            f"Zaptec Poll Update for {obj.qual_id if obj else 'all'}",
+        )
 
 
 class ZaptecBaseEntity(CoordinatorEntity[ZaptecUpdateCoordinator]):
@@ -533,3 +577,7 @@ class ZaptecBaseEntity(CoordinatorEntity[ZaptecUpdateCoordinator]):
                 _LOGGER.error("Unknown zaptec object type: %s", type(obj).__qualname__)
 
         return entities
+
+    async def trigger_poll(self) -> None:
+        """Trigger a poll for this entity."""
+        await self.coordinator.trigger_poll(self.zaptec_obj)

--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -344,13 +344,16 @@ class ZaptecUpdateCoordinator(DataUpdateCoordinator[None]):
 
         what = {obj.id}
         if isinstance(obj, Installation):
-            delay_list = ZAPTEC_POLL_INSTALLATION_TRIGGER_DELAYS
+            delays = ZAPTEC_POLL_INSTALLATION_TRIGGER_DELAYS
             kw = {"state": True, "info": True}
         else:
-            delay_list = ZAPTEC_POLL_CHARGER_TRIGGER_DELAYS
+            delays = ZAPTEC_POLL_CHARGER_TRIGGER_DELAYS
             kw = {"state": True}
 
-        for i, delay in enumerate(delay_list, start=1):
+        # Calculcate the deltas for the delays. E.g. [2, 5, 10] -> [2, 3, 5]
+        deltas = [b - a for a, b in zip([0] + delays[:-1], delays)]
+
+        for i, delay in enumerate(deltas, start=1):
             await asyncio.sleep(delay)
             _LOGGER.debug(
                 "Triggering poll %s of %s after %s seconds. %s",
@@ -372,7 +375,7 @@ class ZaptecUpdateCoordinator(DataUpdateCoordinator[None]):
         self.config_entry.async_create_background_task(
             self.hass,
             self._trigger_poll(obj),
-            f"Zaptec Poll Update for {obj.qual_id if obj else 'all'}",
+            f"Zaptec Poll Update for {obj.qual_id}",
         )
 
 

--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -336,7 +336,7 @@ class ZaptecUpdateCoordinator(DataUpdateCoordinator[None]):
             raise UpdateFailed(err) from err
 
     async def _trigger_poll(self, obj: ZaptecBase) -> None:
-        """Trigger a poll update sequence for the given object or all objects.
+        """Trigger a poll update sequence for the given object.
 
         This sequence is useful to ensure that the state is fully synced after a
         HA initiated update.
@@ -353,13 +353,13 @@ class ZaptecUpdateCoordinator(DataUpdateCoordinator[None]):
         # Calculcate the deltas for the delays. E.g. [2, 5, 10] -> [2, 3, 5]
         deltas = [b - a for a, b in zip([0] + delays[:-1], delays)]
 
-        for i, delay in enumerate(deltas, start=1):
-            await asyncio.sleep(delay)
+        for i, delta in enumerate(deltas, start=1):
+            await asyncio.sleep(delta)
             _LOGGER.debug(
                 "Triggering poll %s of %s after %s seconds. %s",
                 i,
                 obj.qual_id,
-                delay,
+                delta,
                 kw,
             )
             await self.zaptec.poll(what, **kw)

--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -283,8 +283,8 @@ class Installation(ZaptecBase):
                 self.chargers.append(charger)
 
     async def poll_info(self):
-        """Update the installation state."""
-        _LOGGER.debug("Polling state for %s (%s)", self.qual_id, self.get("Name"))
+        """Update the installation info."""
+        _LOGGER.debug("Poll info from %s (%s)", self.qual_id, self.get("Name"))
 
         # Get the installation data
         data = await self.zaptec.request(f"installation/{self.id}")
@@ -304,7 +304,7 @@ class Installation(ZaptecBase):
     async def poll_firmware_info(self):
         """Update the installation firmware info."""
         _LOGGER.debug(
-            "Polling firmware info for %s (%s)", self.qual_id, self.get("Name")
+            "Poll firmware info from %s (%s)", self.qual_id, self.get("Name")
         )
 
         try:
@@ -627,7 +627,7 @@ class Charger(ZaptecBase):
 
     async def poll_state(self):
         """Update the charger state"""
-        _LOGGER.debug("Poll state for %s (%s)", self.qual_id, self.get("Name"))
+        _LOGGER.debug("Poll state from %s (%s)", self.qual_id, self.get("Name"))
 
         # Get the state from the charger
         try:
@@ -661,7 +661,7 @@ class Charger(ZaptecBase):
         - authorize_charge: Authorize the charger to charge
         """
 
-        if command == "authorize_charge":
+        if command in ("authorize_charge", "AuthorizeCharge"):
             return await self.authorize_charge()
 
         # Look up the command and its command id
@@ -670,7 +670,8 @@ class Charger(ZaptecBase):
             cmdid = command
             command = ZCONST.commands.get(cmdid)
         else:
-            cmdid = ZCONST.commands.get(command)
+            # Support using the CommandName as a string
+            cmdid = ZCONST.commands.get(to_under(command))
 
         # Make sure we have a valid command
         if not cmdid or not command:

--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -144,8 +144,11 @@ class ZaptecBase(Mapping[str, TValue]):
     # =======================================================================
     #   UPDATE METHODS
 
-    async def state(self) -> None:
-        """Update the state of the object."""
+    async def poll_info(self) -> None:
+        """Poll information about the object"""
+
+    async def poll_state(self) -> None:
+        """Poll the state of the object"""
 
     def set_attributes(self, data: TDict) -> bool:
         """Set the class attributes from the given data."""
@@ -279,13 +282,50 @@ class Installation(ZaptecBase):
 
                 self.chargers.append(charger)
 
-    async def state(self):
+    async def poll_info(self):
         """Update the installation state."""
-        _LOGGER.debug(
-            "Polling state for %s (%s)", self.qual_id, self._attrs.get("name")
-        )
-        data = await self.installation_info()
+        _LOGGER.debug("Polling state for %s (%s)", self.qual_id, self.get("Name"))
+
+        # Get the installation data
+        data = await self.zaptec.request(f"installation/{self.id}")
+
+        # Remove data fields with excessive data, making it bigger than the
+        # HA database appreciates for the size of attributes.
+        # FIXME: SupportGroup is sub dict. This is not within the declared type
+        supportgroup = data.get("SupportGroup")
+        if supportgroup is not None:
+            if "LogoBase64" in supportgroup:
+                logo = supportgroup["LogoBase64"]
+                supportgroup["LogoBase64"] = f"<Removed, was {len(logo)} bytes>"
+
+        # Set the attributes
         self.set_attributes(data)
+
+    async def poll_firmware_info(self):
+        """Update the installation firmware info."""
+        _LOGGER.debug(
+            "Polling firmware info for %s (%s)", self.qual_id, self.get("Name")
+        )
+
+        try:
+            firmware_info = await self.zaptec.request(
+                f"chargerFirmware/installation/{self.id}"
+            )
+            for fm in firmware_info:
+                charger = self.zaptec.get(fm["ChargerId"])
+                if charger is None:
+                    continue
+                charger.set_attributes(
+                    {
+                        "firmware_current_version": fm["CurrentVersion"],
+                        "firmware_available_version": fm["AvailableVersion"],
+                        "firmware_update_to_date": fm["IsUpToDate"],
+                    }
+                )
+        except RequestError as err:
+            if err.error_code != 403:
+                raise
+            _LOGGER.debug("Access denied to installation %s firmware info", self.id)
 
     #   STREAM METHODS
     # =======================================================================
@@ -475,23 +515,6 @@ class Installation(ZaptecBase):
     #   API METHODS
     # =======================================================================
 
-    async def installation_info(self) -> TDict:
-        """Raw request for installation data."""
-
-        # Get the installation data
-        data = await self.zaptec.request(f"installation/{self.id}")
-
-        # Remove data fields with excessive data, making it bigger than the
-        # HA database appreciates for the size of attributes.
-        # FIXME: SupportGroup is sub dict. This is not within the declared type
-        supportgroup = data.get("SupportGroup")
-        if supportgroup is not None:
-            if "LogoBase64" in supportgroup:
-                logo = supportgroup["LogoBase64"]
-                supportgroup["LogoBase64"] = f"<Removed, was {len(logo)} bytes>"
-
-        return data
-
     async def set_limit_current(self, **kwargs):
         """Set current limit for the installation.
 
@@ -581,15 +604,13 @@ class Charger(ZaptecBase):
 
         self.installation = installation
 
-    async def state(self):
-        """Update the charger state."""
-        _LOGGER.debug(
-            "Polling state for %s (%s)", self.qual_id, self._attrs.get("name")
-        )
+    async def poll_info(self) -> None:
+        """Refresh the charger data"""
+        _LOGGER.debug("Poll info from %s (%s)", self.qual_id, self.get("Name"))
 
         try:
             # Get the main charger info
-            charger = await self.charger_info()
+            charger = await self.zaptec.request(f"chargers/{self.id}")
             self.set_attributes(charger)
         except RequestError as err:
             # An unprivileged user will get a 403 error, but the user is able
@@ -604,6 +625,10 @@ class Charger(ZaptecBase):
                     self.set_attributes(chg)
                     break
 
+    async def poll_state(self):
+        """Update the charger state"""
+        _LOGGER.debug("Poll state for %s (%s)", self.qual_id, self.get("Name"))
+
         # Get the state from the charger
         try:
             state = await self.zaptec.request(f"chargers/{self.id}/state")
@@ -616,52 +641,43 @@ class Charger(ZaptecBase):
                 raise
             _LOGGER.debug("Access denied to charger %s state", self.id)
 
-        # Firmware version is called. SmartMainboardSoftwareApplicationVersion,
-        # stateid 908
-        # I couldn't find a way to see if it was up to date..
-        # maybe remove this later if it dont interest ppl.
-
-        if (installation_id := self["installation_id"]) in self.zaptec:
-            try:
-                firmware_info = await self.zaptec.request(
-                    f"chargerFirmware/installation/{installation_id}"
-                )
-                for fm in firmware_info:
-                    if fm["ChargerId"] == self.id:
-                        self.set_attributes(
-                            {
-                                "current_firmware_version": fm["CurrentVersion"],
-                                "available_firmware_version": fm["AvailableVersion"],
-                                "firmware_update_to_date": fm["IsUpToDate"],
-                            }
-                        )
-            except RequestError as err:
-                if err.error_code != 403:
-                    raise
-                _LOGGER.debug("Access denied to charger %s firmware info", self.id)
-
     #   API METHODS
     # =======================================================================
 
-    async def charger_info(self) -> TDict:
-        """Get the charger info."""
-        data = await self.zaptec.request(f"chargers/{self.id}")
-        return data
-
     async def command(self, command: str | int):
-        """Send a command to the charger."""
+        """Send a command to the charger.
+
+        Any command or command id can be used. Zaptec supports a number of
+        commands, which is found https://api.zaptec.com/help/index.html
+        under CommandId shema. The most used commands are:
+
+        - deauthorize_and_stop: Deauthorize the charger and stop it
+        - restart_charger: Restart the charger
+        - resume_charging: Resume charging
+        - stop_charging_final: Stop charging and set final stop
+        - upgrade_firmware: Upgrade the firmware
+
+        Special commands which is special to this implementation:
+        - authorize_charge: Authorize the charger to charge
+        """
 
         if command == "authorize_charge":
             return await self.authorize_charge()
 
-        self.is_command_valid(command, raise_value_error_if_invalid=True)
-
+        # Look up the command and its command id
         if isinstance(command, int):
             # If int, look up the command name
             cmdid = command
-            command = ZCONST.commands.get(command)
+            command = ZCONST.commands.get(cmdid)
         else:
             cmdid = ZCONST.commands.get(command)
+
+        # Make sure we have a valid command
+        if not cmdid or not command:
+            raise ValueError(f"Unknown command {command!r}")
+
+        # Check that we can run the command at this time
+        self.is_command_valid(command, raise_value_error_if_invalid=True)
 
         _LOGGER.debug("Command %s (%s)", command, cmdid)
         data = await self.zaptec.request(
@@ -670,19 +686,9 @@ class Charger(ZaptecBase):
         return data
 
     def is_command_valid(
-        self, command: str | int, raise_value_error_if_invalid=False
+        self, command: str, raise_value_error_if_invalid=False
     ) -> bool:
         """Check if the command is valid."""
-
-        # Fetching the name from the ZCONST is perhaps not a good idea if Zaptec is changing them.
-        if command not in ZCONST.commands and command != "authorize_charge":
-            if raise_value_error_if_invalid:
-                raise ValueError(f"Unknown command '{command}'")
-            return False
-
-        if isinstance(command, int):
-            # If int, look up the command name
-            command = ZCONST.commands.get(command)
 
         valid_command = True
         msg = ""
@@ -727,26 +733,6 @@ class Charger(ZaptecBase):
             f"chargers/{self.id}/update", method="post", data=settings
         )
         return data
-
-    async def stop_charging_final(self):
-        """Send stop charging command."""
-        return await self.command("stop_charging_final")
-
-    async def resume_charging(self):
-        """Send resume charging command."""
-        return await self.command("resume_charging")
-
-    async def deauthorize_and_stop(self):
-        """Deauthorize the charger and stop it."""
-        return await self.command("deauthorize_and_stop")
-
-    async def restart_charger(self):
-        """Restart the charger."""
-        return await self.command("restart_charger")
-
-    async def upgrade_firmware(self):
-        """Send command to upgrade firmware."""
-        return await self.command("upgrade_firmware")
 
     async def authorize_charge(self):
         """Authorize the charger to charge."""
@@ -1156,7 +1142,7 @@ class Zaptec(Mapping[str, ZaptecBase]):
             # Add or update the installation object.
             if inst_item["Id"] in self:
                 _LOGGER.debug("  Installation %s  (existing)", inst_item["Id"])
-                installation = self[inst_item["Id"]]
+                installation: Installation = self[inst_item["Id"]]
                 installation.set_attributes(inst_item)
             else:
                 _LOGGER.debug("  Installation %s", inst_item["Id"])
@@ -1191,15 +1177,32 @@ class Zaptec(Mapping[str, ZaptecBase]):
 
         # Update the observation, settings and commands ids based on the
         # discovered device types.
-        ZCONST.update_ids_from_schema({chg["device_type"] for chg in self.chargers})
+        ZCONST.update_ids_from_schema({chg["DeviceType"] for chg in self.chargers})
 
         self.is_built = True
 
-    async def update_states(self, id: str | None = None):
-        """Update the state for the given id or update all."""
-        for obj in self.objects():
-            if id is None or obj.id == id:
-                await obj.state()
+    async def poll(
+        self,
+        objs: Iterable[str] | None = None,
+        *,
+        info: bool = False,
+        state: bool = True,
+        firmware: bool = False,
+    ):
+        """Update the info and state from Zaptec."""
+        if objs is None:
+            objs = iter(self)
+
+        for objid in objs:
+            obj = self.get(objid)
+            if obj is None:
+                raise ValueError(f"Object with id {objid} not found")
+            if info:
+                await obj.poll_info()
+            if state:
+                await obj.poll_state()
+            if firmware and isinstance(obj, Installation):
+                await obj.poll_firmware_info()
 
 
 if __name__ == "__main__":

--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -32,7 +32,7 @@ from .const import (
 )
 from .misc import mc_nbfx_decoder, to_under
 from .validate import validate
-from .zconst import ZConst
+from .zconst import ZConst, CommandType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -644,7 +644,7 @@ class Charger(ZaptecBase):
     #   API METHODS
     # =======================================================================
 
-    async def command(self, command: str | int):
+    async def command(self, command: str | int | CommandType):
         """Send a command to the charger.
 
         Any command or command id can be used. Zaptec supports a number of

--- a/custom_components/zaptec/button.py
+++ b/custom_components/zaptec/button.py
@@ -28,11 +28,7 @@ class ZaptecButton(ZaptecBaseEntity, ButtonEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        if not self._attr_available:
-            return False
-        else:
-            # Disable/gray out button if the command is invalid in the current state
-            return self.zaptec_obj.is_command_valid(self.key)
+        return super().available and self.zaptec_obj.is_command_valid(self.key)
 
     async def async_press(self) -> None:
         """Press the button."""
@@ -47,7 +43,7 @@ class ZaptecButton(ZaptecBaseEntity, ButtonEntity):
         except Exception as exc:
             raise HomeAssistantError(f"Running command '{self.key}' failed") from exc
 
-        await self.coordinator.async_request_refresh()
+        await self.trigger_poll()
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/zaptec/config_flow.py
+++ b/custom_components/zaptec/config_flow.py
@@ -105,8 +105,8 @@ class ZaptecFlowHandler(ConfigFlow, domain=DOMAIN):
 
         def charger_text(charger: Charger):
             """Format the charger text for display."""
-            text = f"{charger.name} ({charger.get('device_id', '-')})"
-            if circuit := charger.get("circuit_name"):
+            text = f"{charger.name} ({charger.get('DeviceId', '-')})"
+            if circuit := charger.get("CircuitName"):
                 text += f" in {circuit} circuit"
             if charger.installation:
                 text += f" of {charger.installation.name} installation"

--- a/custom_components/zaptec/const.py
+++ b/custom_components/zaptec/const.py
@@ -37,6 +37,12 @@ API_RATELIMIT_PERIOD = 1
 API_RATELIMIT_MAX_REQUEST_RATE = 10
 """Maximum number of requests allowed per API rate limit period."""
 
+ZAPTEC_POLL_CHARGER_TRIGGER_DELAYS = [2, 5, 7]
+""" Sequence of delays in seconds for state updates to a charger after a change."""
+
+ZAPTEC_POLL_INSTALLATION_TRIGGER_DELAYS = [2, 5]
+""" Sequence of delays in seconds for state updates to a installation after a change."""
+
 DEFAULT_SCAN_INTERVAL = 60
 """Default scan interval for state updates."""
 

--- a/custom_components/zaptec/const.py
+++ b/custom_components/zaptec/const.py
@@ -37,11 +37,11 @@ API_RATELIMIT_PERIOD = 1
 API_RATELIMIT_MAX_REQUEST_RATE = 10
 """Maximum number of requests allowed per API rate limit period."""
 
-ZAPTEC_POLL_CHARGER_TRIGGER_DELAYS = [2, 5, 7]
-""" Sequence of delays in seconds for state updates to a charger after a change."""
+ZAPTEC_POLL_CHARGER_TRIGGER_DELAYS = [2, 7, 15]
+"""Delays in seconds for charger state updates after a change."""
 
-ZAPTEC_POLL_INSTALLATION_TRIGGER_DELAYS = [2, 5]
-""" Sequence of delays in seconds for state updates to a installation after a change."""
+ZAPTEC_POLL_INSTALLATION_TRIGGER_DELAYS = [2, 7]
+"""Delays in seconds for installation state updates after a change."""
 
 DEFAULT_SCAN_INTERVAL = 60
 """Default scan interval for state updates."""

--- a/custom_components/zaptec/lock.py
+++ b/custom_components/zaptec/lock.py
@@ -52,7 +52,7 @@ class ZaptecCableLock(ZaptecLock):
         except Exception as exc:
             raise HomeAssistantError("Removing permanent cable lock failed") from exc
 
-        await self.coordinator.async_request_refresh()
+        await self.trigger_poll()
 
     async def async_lock(self, **kwargs) -> None:
         """Lock the cable lock."""
@@ -67,7 +67,7 @@ class ZaptecCableLock(ZaptecLock):
         except Exception as exc:
             raise HomeAssistantError("Setting permanent cable lock failed") from exc
 
-        await self.coordinator.async_request_refresh()
+        await self.trigger_poll()
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/zaptec/number.py
+++ b/custom_components/zaptec/number.py
@@ -49,7 +49,7 @@ class ZaptecAvailableCurrentNumber(ZaptecNumber):
     def _post_init(self):
         # Get the max current rating from the reported max current
         self.entity_description.native_max_value = self.zaptec_obj.get(
-            "max_current", 32
+            "MaxCurrent", 32
         )
 
     async def async_set_native_value(self, value: float) -> None:
@@ -67,7 +67,7 @@ class ZaptecAvailableCurrentNumber(ZaptecNumber):
         except Exception as exc:
             raise HomeAssistantError(f"Set current limit to {value} failed") from exc
 
-        await self.coordinator.async_request_refresh()
+        await self.trigger_poll()
 
 
 class ZaptecSettingNumber(ZaptecNumber):
@@ -79,7 +79,7 @@ class ZaptecSettingNumber(ZaptecNumber):
     def _post_init(self):
         # Get the max current rating from the reported max current
         self.entity_description.native_max_value = self.zaptec_obj.get(
-            "charge_current_installation_max_limit", 32
+            "ChargeCurrentInstallationMaxLimit", 32
         )
 
     async def async_set_native_value(self, value: float) -> None:
@@ -100,7 +100,7 @@ class ZaptecSettingNumber(ZaptecNumber):
                 f"Setting {self.entity_description.setting} to {value} failed"
             ) from exc
 
-        await self.coordinator.async_request_refresh()
+        await self.trigger_poll()
 
 
 class ZaptecHmiBrightness(ZaptecNumber):
@@ -134,7 +134,7 @@ class ZaptecHmiBrightness(ZaptecNumber):
         except Exception as exc:
             raise HomeAssistantError(f"Set HmiBrightness to {value} failed") from exc
 
-        await self.coordinator.async_request_refresh()
+        await self.trigger_poll()
 
 
 # FIXME: Using @dataclass(frozen=True, kw_only=True) doesn't work when using

--- a/custom_components/zaptec/services.py
+++ b/custom_components/zaptec/services.py
@@ -225,24 +225,24 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         for coordinator, obj in iter_objects(service_call, Charger):
             _LOGGER.debug("  >> to %s", obj.id)
             try:
-                await obj.stop_charging_final()
+                await obj.command("stop_charging_final")
             except Exception as exc:
                 raise HomeAssistantError(
                     f"Command 'stop_charging_final' failed: {exc}"
                 ) from exc
-            await coordinator.async_request_refresh()
+            await coordinator.trigger_poll(obj)
 
     async def service_handle_resume_charging(service_call: ServiceCall) -> None:
         _LOGGER.debug("Called resume charging")
         for coordinator, obj in iter_objects(service_call, mustbe=Charger):
             _LOGGER.debug("  >> to %s", obj.id)
             try:
-                await obj.resume_charging()
+                await obj.command("resume_charging")
             except Exception as exc:
                 raise HomeAssistantError(
                     f"Command 'resume_charging' failed: {exc}"
                 ) from exc
-            await coordinator.async_request_refresh()
+            await coordinator.trigger_poll(obj)
 
     async def service_handle_authorize_charging(service_call: ServiceCall) -> None:
         _LOGGER.debug("Called authorize charging")
@@ -254,43 +254,43 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 raise HomeAssistantError(
                     f"Command 'authorize_charge' failed: {exc}"
                 ) from exc
-            await coordinator.async_request_refresh()
+            await coordinator.trigger_poll(obj)
 
     async def service_handle_deauthorize_charging(service_call: ServiceCall) -> None:
         _LOGGER.debug("Called deauthorize charging and stop")
         for coordinator, obj in iter_objects(service_call, mustbe=Charger):
             _LOGGER.debug("  >> to %s", obj.id)
             try:
-                await obj.deauthorize_and_stop()
+                await obj.command("deauthorize_and_stop")
             except Exception as exc:
                 raise HomeAssistantError(
                     f"Command 'deauthorize_and_stop' failed: {exc}"
                 ) from exc
-            await coordinator.async_request_refresh()
+            await coordinator.trigger_poll(obj)
 
     async def service_handle_restart_charger(service_call: ServiceCall) -> None:
         _LOGGER.debug("Called restart charger")
         for coordinator, obj in iter_objects(service_call, mustbe=Charger):
             _LOGGER.debug("  >> to %s", obj.id)
             try:
-                await obj.restart_charger()
+                await obj.command("restart_charger")
             except Exception as exc:
                 raise HomeAssistantError(
                     f"Command 'restart_charger' failed: {exc}"
                 ) from exc
-            await coordinator.async_request_refresh()
+            await coordinator.trigger_poll(obj)
 
     async def service_handle_upgrade_firmware(service_call: ServiceCall) -> None:
         _LOGGER.debug("Called update firmware")
         for coordinator, obj in iter_objects(service_call, mustbe=Charger):
             _LOGGER.debug("  >> to %s", obj.id)
             try:
-                await obj.upgrade_firmware()
+                await obj.command("upgrade_firmware")
             except Exception as exc:
                 raise HomeAssistantError(
                     f"Command 'upgrade_firmware' failed: {exc}"
                 ) from exc
-            await coordinator.async_request_refresh()
+            await coordinator.trigger_poll(obj)
 
     async def service_handle_limit_current(service_call: ServiceCall) -> None:
         _LOGGER.debug("Called set current limit")
@@ -309,7 +309,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 )
             except Exception as exc:
                 raise HomeAssistantError(f"Limit current failed: {exc}") from exc
-            await coordinator.async_request_refresh()
+            await coordinator.trigger_poll(obj)
 
     async def service_handle_send_command(service_call: ServiceCall) -> None:
         _LOGGER.debug("Called send command")
@@ -320,7 +320,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 await obj.command(command)
             except Exception as exc:
                 raise HomeAssistantError(f"Command '{command}' failed: {exc}") from exc
-            await coordinator.async_request_refresh()
+            await coordinator.trigger_poll(obj)
 
     # LIST OF SERVICES
     services: list[tuple[str, vol.Schema, TServiceHandler]] = [

--- a/custom_components/zaptec/switch.py
+++ b/custom_components/zaptec/switch.py
@@ -64,11 +64,11 @@ class ZaptecChargeSwitch(ZaptecSwitch):
         )
 
         try:
-            await self.zaptec_obj.resume_charging()
+            await self.zaptec_obj.command("resume_charging")
         except Exception as exc:
             raise HomeAssistantError("Resuming charging failed") from exc
 
-        await self.coordinator.async_request_refresh()
+        await self.trigger_poll()
 
     async def async_turn_off(self, **kwargs):  # pylint: disable=unused-argument
         """Turn off the switch."""
@@ -79,11 +79,11 @@ class ZaptecChargeSwitch(ZaptecSwitch):
         )
 
         try:
-            await self.zaptec_obj.stop_charging_final()
+            await self.zaptec_obj.command("stop_charging_final")
         except Exception as exc:
             raise HomeAssistantError("Stop/pausing charging failed") from exc
 
-        await self.coordinator.async_request_refresh()
+        await self.trigger_poll()
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/zaptec/update.py
+++ b/custom_components/zaptec/update.py
@@ -34,10 +34,10 @@ class ZaptecUpdate(ZaptecBaseEntity, UpdateEntity):
         """Update the entity from Zaptec data."""
         try:
             self._attr_installed_version = self._get_zaptec_value(
-                key="current_firmware_version"
+                key="firmware_current_version"
             )
             self._attr_latest_version = self._get_zaptec_value(
-                key="available_firmware_version"
+                key="firmware_available_version"
             )
             self._attr_available = True
             self._log_value(self._attr_installed_version)
@@ -54,11 +54,11 @@ class ZaptecUpdate(ZaptecBaseEntity, UpdateEntity):
         )
 
         try:
-            await self.zaptec_obj.upgrade_firmware()
+            await self.zaptec_obj.command("upgrade_firmware")
         except Exception as exc:
             raise HomeAssistantError("Sending update firmware command failed") from exc
 
-        await self.coordinator.async_request_refresh()
+        await self.trigger_poll()
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/zaptec/zconst.py
+++ b/custom_components/zaptec/zconst.py
@@ -1,13 +1,25 @@
 """Main API for Zaptec."""
+
 from __future__ import annotations
 
+from collections import UserDict
 import json
 import logging
-from collections import UserDict
+from typing import Literal
 
 from .misc import to_under
 
 _LOGGER = logging.getLogger(__name__)
+
+type CommandType = Literal[
+    "RestartCharger",
+    "UpgradeFirmware",
+    "StopChargingFinal",
+    "ResumeCharging",
+    "DeauthorizeAndStop",
+    "AuthorizeCharge",  # Not official command, used by the integration
+]
+"""Approved API commands."""
 
 
 #
@@ -19,14 +31,17 @@ class ZConst(UserDict):
     observations: dict[str, int]
     settings: dict[str, int]
     commands: dict[str, int]
-    update_params=[
+    """Mapping of command name to command id and id to name."""
+
+    update_params = [
         "maxChargeCurrent",
         "maxChargePhases",
         "minChargeCurrent",
         "offlineChargeCurrent",
         "offlineChargePhase",
         "meterValueInterval",
-    ] # valid parameters for api/chargers/{id}/update
+    ]
+    """Valid parameters for charger settings (`chargers/{id}/update`)."""
 
     def get_remap(self, wanted, device_types=None) -> dict:
         """Parse the given zaptec constants record `CONST` and generate


### PR DESCRIPTION
- New feature: When HA initiates a change or command, the integration will poll the device 2, 5 and 14 seconds after to fetch updated data quickly.
- Introduced polling methods for charger and installation updates.
- Replaced direct state updates with trigger_poll calls in various components.
- Updated command handling in services and entities to use a unified command method.
- Removed direct commands in favor of the command method

> [!NOTE]
> This PR contains a known issue: It contains a new feature which issue a sequence of polls immediately after any HA imitated command or change. If HA makes very frequent changes (<20 secs), there might be many updates running in parallel for the same resource which is not good. This is planned to be fixed in a later PR.
