### PR TITLE
Refactor Zaptec integration for prepping to adopt to API policy

### DIFF
--- a/custom_components/zaptec/binary_sensor.py
+++ b/custom_components/zaptec/binary_sensor.py
@@ -11,13 +11,11 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import ZaptecBaseEntity, ZaptecUpdateCoordinator
-from .const import DOMAIN
+from . import ZaptecBaseEntity, ZaptecConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,7 +47,7 @@ class ZaptecBinarySensorWithAttrs(ZaptecBinarySensor):
 class ZapBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Class describing Zaptec binary sensor entities."""
 
-    cls: type | None = None
+    cls: type[BinarySensorEntity]
 
 
 INSTALLATION_ENTITIES: list[EntityDescription] = [
@@ -70,6 +68,7 @@ INSTALLATION_ENTITIES: list[EntityDescription] = [
         translation_key="authorization_required",
         entity_category=const.EntityCategory.DIAGNOSTIC,
         icon="mdi:lock",
+        cls=ZaptecBinarySensor,
     ),
 ]
 
@@ -96,20 +95,18 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         translation_key="authorization_required",
         entity_category=const.EntityCategory.DIAGNOSTIC,
         icon="mdi:lock",
+        cls=ZaptecBinarySensor,
     ),
 ]
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ZaptecConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Zaptec binary sensors."""
-    _LOGGER.debug("Setup binary sensors")
-
-    coordinator: ZaptecUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
-    entities = ZaptecBinarySensor.create_from_zaptec(
-        coordinator,
+    entities = entry.runtime_data.create_entities_from_zaptec(
         INSTALLATION_ENTITIES,
         CHARGER_ENTITIES,
     )

--- a/custom_components/zaptec/button.py
+++ b/custom_components/zaptec/button.py
@@ -7,15 +7,13 @@ import logging
 
 from homeassistant import const
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import ZaptecBaseEntity, ZaptecUpdateCoordinator
+from . import ZaptecBaseEntity, ZaptecConfigEntry
 from .api import Charger
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +48,7 @@ class ZaptecButton(ZaptecBaseEntity, ButtonEntity):
 class ZapButtonEntityDescription(ButtonEntityDescription):
     """Class describing Zaptec button entities."""
 
-    cls: type | None = None
+    cls: type[ButtonEntity]
 
 
 INSTALLATION_ENTITIES: list[EntityDescription] = []
@@ -60,47 +58,50 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         key="resume_charging",
         translation_key="resume_charging",
         icon="mdi:play-circle-outline",
+        cls=ZaptecButton,
     ),
     ZapButtonEntityDescription(
         key="stop_charging_final",
         translation_key="stop_charging",
         icon="mdi:pause-circle-outline",
+        cls=ZaptecButton,
     ),
     ZapButtonEntityDescription(
         key="authorize_charge",
         translation_key="authorize_charge",
         icon="mdi:lock-check-outline",
+        cls=ZaptecButton,
     ),
     ZapButtonEntityDescription(
         key="deauthorize_and_stop",
         translation_key="deauthorize_and_stop",
         icon="mdi:lock-remove-outline",
+        cls=ZaptecButton,
     ),
     ZapButtonEntityDescription(
         key="restart_charger",
         translation_key="restart_charger",
         entity_category=const.EntityCategory.DIAGNOSTIC,
         icon="mdi:restart",
+        cls=ZaptecButton,
     ),
     ZapButtonEntityDescription(
         key="upgrade_firmware",
         translation_key="upgrade_firmware",
         entity_category=const.EntityCategory.DIAGNOSTIC,
         icon="mdi:memory",
+        cls=ZaptecButton,
     ),
 ]
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ZaptecConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Zaptec buttons."""
-    _LOGGER.debug("Setup buttons")
-
-    coordinator: ZaptecUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
-    entities = ZaptecButton.create_from_zaptec(
-        coordinator,
+    entities = entry.runtime_data.create_entities_from_zaptec(
         INSTALLATION_ENTITIES,
         CHARGER_ENTITIES,
     )

--- a/custom_components/zaptec/config_flow.py
+++ b/custom_components/zaptec/config_flow.py
@@ -235,12 +235,6 @@ class ZaptecFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_import(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Import a config entry from YAML."""
-        return await self.async_step_user()
-
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/custom_components/zaptec/diagnostics.py
+++ b/custom_components/zaptec/diagnostics.py
@@ -11,7 +11,7 @@ if __name__ != "__main__":
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.device_registry import DeviceEntry
 
-from . import ZaptecUpdateCoordinator
+from . import ZaptecConfigEntry, ZaptecManager
 from .api import ZCONST, Zaptec
 from .const import DOMAIN
 
@@ -172,13 +172,13 @@ class Redactor:
 
 
 async def async_get_device_diagnostics(
-    hass: HomeAssistant, config_entry: ConfigEntry, device: DeviceEntry
+    hass: HomeAssistant, config_entry: ZaptecConfigEntry, device: DeviceEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a device."""
 
     out = {}
-    coordinator: ZaptecUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    zaptec: Zaptec = coordinator.zaptec
+    manager: ZaptecManager = config_entry.runtime_data
+    zaptec: Zaptec = manager.zaptec
 
     # Helper to redact the output data
     red = Redactor(DO_REDACT, ZCONST.observations)

--- a/custom_components/zaptec/lock.py
+++ b/custom_components/zaptec/lock.py
@@ -7,14 +7,12 @@ import logging
 
 from homeassistant import const
 from homeassistant.components.lock import LockEntity, LockEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import ZaptecBaseEntity, ZaptecUpdateCoordinator
+from . import ZaptecBaseEntity, ZaptecConfigEntry
 from .api import Charger
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,7 +72,7 @@ class ZaptecCableLock(ZaptecLock):
 class ZapLockEntityDescription(LockEntityDescription):
     """Class describing Zaptec lock entities."""
 
-    cls: type | None = None
+    cls: type[LockEntity]
 
 
 INSTALLATION_ENTITIES: list[ZapLockEntityDescription] = []
@@ -90,16 +88,13 @@ CHARGER_ENTITIES: list[ZapLockEntityDescription] = [
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ZaptecConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Zaptec locks."""
-    _LOGGER.debug("Setup lock entry")
-
-    coordinator: ZaptecUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
-    entitites = ZaptecLock.create_from_zaptec(
-        coordinator,
+    entities = entry.runtime_data.create_entities_from_zaptec(
         INSTALLATION_ENTITIES,
         CHARGER_ENTITIES,
     )
-    async_add_entities(entitites, True)
+    async_add_entities(entities, True)

--- a/custom_components/zaptec/number.py
+++ b/custom_components/zaptec/number.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import logging
 
 from homeassistant import const
@@ -11,16 +11,14 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import ZaptecBaseEntity, ZaptecUpdateCoordinator
+from . import ZaptecBaseEntity, ZaptecConfigEntry
 from .api import Charger, Installation
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,8 +46,11 @@ class ZaptecAvailableCurrentNumber(ZaptecNumber):
 
     def _post_init(self):
         # Get the max current rating from the reported max current
-        self.entity_description.native_max_value = self.zaptec_obj.get(
-            "MaxCurrent", 32
+        self.entity_description = replace(
+            self.entity_description,
+            native_max_value = self.zaptec_obj.get(
+                "MaxCurrent", 32
+            ),
         )
 
     async def async_set_native_value(self, value: float) -> None:
@@ -78,8 +79,11 @@ class ZaptecSettingNumber(ZaptecNumber):
 
     def _post_init(self):
         # Get the max current rating from the reported max current
-        self.entity_description.native_max_value = self.zaptec_obj.get(
-            "ChargeCurrentInstallationMaxLimit", 32
+        self.entity_description = replace(
+            self.entity_description,
+            native_max_value = self.zaptec_obj.get(
+                "ChargeCurrentInstallationMaxLimit", 32
+            ),
         )
 
     async def async_set_native_value(self, value: float) -> None:
@@ -137,14 +141,11 @@ class ZaptecHmiBrightness(ZaptecNumber):
         await self.trigger_poll()
 
 
-# FIXME: Using @dataclass(frozen=True, kw_only=True) doesn't work when using
-# _post_init() to update the value. This must be fixed. Either the _post_init()
-# should be removed or the dataclass should be changed to non-frozen class.
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class ZapNumberEntityDescription(NumberEntityDescription):
     """Class describing Zaptec number entities."""
 
-    cls: type | None = None
+    cls: type[NumberEntity]
     setting: str | None = None
 
 
@@ -198,15 +199,12 @@ CHARGER_ENTITIES: list[EntityDescription] = [
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ZaptecConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Zaptec numbers."""
-    _LOGGER.debug("Setup numbers")
-
-    coordinator: ZaptecUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
-    entities = ZaptecNumber.create_from_zaptec(
-        coordinator,
+    entities = entry.runtime_data.create_entities_from_zaptec(
         INSTALLATION_ENTITIES,
         CHARGER_ENTITIES,
     )

--- a/custom_components/zaptec/sensor.py
+++ b/custom_components/zaptec/sensor.py
@@ -12,17 +12,12 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import ZaptecBaseEntity, ZaptecUpdateCoordinator
+from . import ZaptecBaseEntity, ZaptecConfigEntry
 from .api import ZCONST
-from .const import DOMAIN
-
-# pylint: disable=missing-function-docstring
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,7 +68,7 @@ class ZaptecChargeSensor(ZaptecSensor):
 class ZapSensorEntityDescription(SensorEntityDescription):
     """Provide a description of a Zaptec sensor."""
 
-    cls: type | None = None
+    cls: type[SensorEntity]
 
 
 INSTALLATION_ENTITIES: list[EntityDescription] = [
@@ -84,6 +79,7 @@ INSTALLATION_ENTITIES: list[EntityDescription] = [
         icon="mdi:current-ac",
         native_unit_of_measurement=const.UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="available_current_phase2",
@@ -92,6 +88,7 @@ INSTALLATION_ENTITIES: list[EntityDescription] = [
         icon="mdi:current-ac",
         native_unit_of_measurement=const.UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="available_current_phase3",
@@ -100,6 +97,7 @@ INSTALLATION_ENTITIES: list[EntityDescription] = [
         icon="mdi:current-ac",
         native_unit_of_measurement=const.UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="max_current",
@@ -109,6 +107,7 @@ INSTALLATION_ENTITIES: list[EntityDescription] = [
         icon="mdi:current-ac",
         native_unit_of_measurement=const.UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="authentication_type",
@@ -117,6 +116,7 @@ INSTALLATION_ENTITIES: list[EntityDescription] = [
         entity_category=const.EntityCategory.DIAGNOSTIC,
         options=ZCONST.installation_authentication_type_list,
         icon="mdi:key-change",
+        cls=ZaptecSensor,
         # No state class as its not a numeric value
     ),
     ZapSensorEntityDescription(
@@ -126,6 +126,7 @@ INSTALLATION_ENTITIES: list[EntityDescription] = [
         entity_category=const.EntityCategory.DIAGNOSTIC,
         options=ZCONST.installation_types_list,
         icon="mdi:shape-outline",
+        cls=ZaptecSensor,
         # No state class as its not a numeric value
     ),
     ZapSensorEntityDescription(
@@ -135,6 +136,7 @@ INSTALLATION_ENTITIES: list[EntityDescription] = [
         entity_category=const.EntityCategory.DIAGNOSTIC,
         options=ZCONST.network_types_list,
         icon="mdi:waves-arrow-up",
+        cls=ZaptecSensor,
         # No state class as its not a numeric value
     ),
 ]
@@ -156,6 +158,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         icon="mdi:current-ac",
         native_unit_of_measurement=const.UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="current_phase2",
@@ -164,6 +167,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         icon="mdi:current-ac",
         native_unit_of_measurement=const.UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="current_phase3",
@@ -172,6 +176,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         icon="mdi:current-ac",
         native_unit_of_measurement=const.UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="voltage_phase1",
@@ -180,6 +185,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         icon="mdi:sine-wave",
         native_unit_of_measurement=const.UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="voltage_phase2",
@@ -188,6 +194,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         icon="mdi:sine-wave",
         native_unit_of_measurement=const.UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="voltage_phase3",
@@ -196,6 +203,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         icon="mdi:sine-wave",
         native_unit_of_measurement=const.UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="total_charge_power",
@@ -204,6 +212,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         icon="mdi:flash",
         native_unit_of_measurement=const.UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="total_charge_power_session",
@@ -212,6 +221,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         icon="mdi:counter",
         native_unit_of_measurement=const.UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="signed_meter_value_kwh",
@@ -220,6 +230,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         icon="mdi:counter",
         native_unit_of_measurement=const.UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="completed_session.Energy",
@@ -228,6 +239,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         icon="mdi:counter",
         native_unit_of_measurement=const.UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="humidity",
@@ -237,6 +249,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         native_unit_of_measurement=const.PERCENTAGE,
         entity_category=const.EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="temperature_internal5",
@@ -246,6 +259,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         native_unit_of_measurement=const.UnitOfTemperature.CELSIUS,
         entity_category=const.EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="charge_current_set",
@@ -254,6 +268,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         icon="mdi:current-ac",
         native_unit_of_measurement=const.UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
+        cls=ZaptecSensor,
     ),
     ZapSensorEntityDescription(
         key="device_type",
@@ -262,21 +277,19 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         entity_category=const.EntityCategory.DIAGNOSTIC,
         options=ZCONST.device_types_list,
         icon="mdi:shape-outline",
+        cls=ZaptecSensor,
         # No state class as its not a numeric value
     ),
 ]
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ZaptecConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Zaptec sensors."""
-    _LOGGER.debug("Setup sensors")
-
-    coordinator: ZaptecUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
-    entities = ZaptecSensor.create_from_zaptec(
-        coordinator,
+    entities = entry.runtime_data.create_entities_from_zaptec(
         INSTALLATION_ENTITIES,
         CHARGER_ENTITIES,
     )

--- a/custom_components/zaptec/services.py
+++ b/custom_components/zaptec/services.py
@@ -17,7 +17,7 @@ from .api import Charger, Installation
 from .const import DOMAIN
 
 if TYPE_CHECKING:
-    from . import ZaptecUpdateCoordinator
+    from . import ZaptecUpdateCoordinator, ZaptecManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -116,7 +116,7 @@ SEND_COMMAND_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup_services(hass: HomeAssistant) -> None:
+async def async_setup_services(hass: HomeAssistant, manager: ZaptecManager) -> None:
     """Set up services for zaptec."""
     _LOGGER.debug("Set up services")
 
@@ -188,9 +188,8 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
             # Get all coordinators and objects that matches the uid from all coordinator objects
             matches = set(
-                (coord, obj)
-                for coord in hass.data[DOMAIN].values()
-                for obj in coord.zaptec.objects()
+                (manager.coordinator, obj)
+                for obj in manager.zaptec.objects()
                 if obj.id == uid
             )
             # Filter out the objects that doesn't match the expected type

--- a/custom_components/zaptec/switch.py
+++ b/custom_components/zaptec/switch.py
@@ -10,15 +10,13 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import ZaptecBaseEntity, ZaptecUpdateCoordinator
+from . import ZaptecBaseEntity, ZaptecConfigEntry
 from .api import Charger
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,12 +88,12 @@ class ZaptecChargeSwitch(ZaptecSwitch):
 class ZapSwitchEntityDescription(SwitchEntityDescription):
     """Class describing Zaptec switch entities."""
 
-    cls: type | None = None
+    cls: type[SwitchEntity]
 
 
-INSTALLATION_SWITCH_TYPES: list[EntityDescription] = []
+INSTALLATION_ENTITIES: list[EntityDescription] = []
 
-CHARGER_SWITCH_TYPES: list[EntityDescription] = [
+CHARGER_ENTITIES: list[EntityDescription] = [
     ZapSwitchEntityDescription(
         key="operating_mode",
         translation_key="operating_mode",
@@ -106,16 +104,13 @@ CHARGER_SWITCH_TYPES: list[EntityDescription] = [
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ZaptecConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Zaptec switches."""
-    _LOGGER.debug("Setup switches")
-
-    coordinator: ZaptecUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
-    entities = ZaptecSwitch.create_from_zaptec(
-        coordinator,
-        INSTALLATION_SWITCH_TYPES,
-        CHARGER_SWITCH_TYPES,
+    entities = entry.runtime_data.create_entities_from_zaptec(
+        INSTALLATION_ENTITIES,
+        CHARGER_ENTITIES,
     )
     async_add_entities(entities, True)


### PR DESCRIPTION
This PR introduces a lot of refactoring to do several things
- Modernize the way the integration is set up - move toward HA coding ideals, keeping the door open to future inclusion into HA.
- Introduce a ZaptecManager that will later allow us to store multiple coordinator. This will be required to do the elaborate polling setup that Zaptec wants, see #202 

> [!WARNING]
> Currently this is WIP/draft and rather untested, but adding it here so its possible to do early reviews on it. All input helps.

From commit message:
- Introduced ZaptecManager to handle instance data and coordination of updates.
- It is preparations for running multiple coordinators
- Updated async_setup_entry to utilize the new manager
- Refactored entity creation methods to be part of the manager
- Adjusted all platform files (binary_sensor, button, lock, number, sensor, switch, update) to align with the new structure.
- Cleaned up unnecessary imports and comments, enhancing code readability.
- Removed YAML import step from config flow as it is no longer needed.