### PR TITLE
Add setting to enable if entity is to be checked on startup

### DIFF
--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -69,6 +69,14 @@ PLATFORMS = [
     Platform.UPDATE,
 ]
 
+CHECK_ENTITY_AVAILABLE_ON_ADD = False
+"""Enable a check to ensure that the entity is available when added.
+
+If not available, the entity will not be added to the list of entities.
+For Zaptec, this is not recommended, as some attributes are not always
+available. E.g. "TotalChargePowerSession" is only present under certain
+conditions.
+"""
 
 class KeyUnavailableError(Exception):
     """Exception raised when a key is not available in the Zaptec object."""
@@ -358,20 +366,21 @@ class ZaptecManager:
                 device_info=dev_info,
             )
 
-            # Check if the zaptec data for the object is available before
-            # adding it to the list of entities. The caveat is that if the
-            # entity have been added earlier, it will now be listed as
-            # "This entity is no longer being provided by the zaptec integration."
-            updater = getattr(entity, "_update_from_zaptec", lambda: None)
-            try:
-                updater()
-            except Exception:
-                _LOGGER.exception(
-                    "Failed to add entity %s keys %s, skipping entity",
-                    cls.__name__,
-                    description.key,
-                )
-                continue
+            if CHECK_ENTITY_AVAILABLE_ON_ADD:
+                # Check if the zaptec data for the object is available before
+                # adding it to the list of entities. The caveat is that if the
+                # entity have been added earlier, it will now be listed as
+                # "This entity is no longer being provided by the zaptec integration."
+                updater = getattr(entity, "_update_from_zaptec", lambda: None)
+                try:
+                    updater()
+                except Exception:
+                    _LOGGER.exception(
+                        "Failed to add entity %s keys %s, skipping entity",
+                        cls.__name__,
+                        description.key,
+                    )
+                    continue
 
             entities.append(entity)
 

--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -393,7 +393,7 @@ class ZaptecManager:
                 updater()
             except Exception:
                 if description.key in KEYS_TO_SKIP_ENTITY_AVAILABILITY_CHECK:
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "Entity %s key %s is not available in Zaptec, but adding anyway",
                         cls.__name__,
                         description.key,
@@ -682,6 +682,7 @@ class ZaptecBaseEntity(CoordinatorEntity[ZaptecUpdateCoordinator]):
     entity_description: EntityDescription
     _attr_has_entity_name = True
     _prev_value: Any = MISSING
+    _prev_available: bool = True  # Assume the entity is available at start for logging
     _log_attribute: str | None = None
     """The attribute to log when the value changes."""
 
@@ -728,14 +729,14 @@ class ZaptecBaseEntity(CoordinatorEntity[ZaptecUpdateCoordinator]):
         available. This function will log the value if it changes or becomes
         unavailable.
         """
-        prev_available = self._attr_available
         update_from_zaptec = getattr(self, "_update_from_zaptec", lambda: None)
         try:
             update_from_zaptec()
             self._log_value(self._log_attribute)
+            self._log_unavailable()  # For logging when the entity becomes available again
         except KeyUnavailableError as exc:
             self._attr_available = False
-            self._log_unavailable(exc, prev_available)
+            self._log_unavailable(exc)
         super()._handle_coordinator_update()
 
     @callback
@@ -787,10 +788,9 @@ class ZaptecBaseEntity(CoordinatorEntity[ZaptecUpdateCoordinator]):
         if attribute is None:
             return
         value = getattr(self, attribute, MISSING)
-        prev = self._prev_value
 
         # Only logs when the value changes
-        if force or value != prev:
+        if force or value != self._prev_value:
             self._prev_value = value
             _LOGGER.debug(
                 "    %s  =  %s <%s>   from %s%s",
@@ -802,17 +802,15 @@ class ZaptecBaseEntity(CoordinatorEntity[ZaptecUpdateCoordinator]):
             )
 
     @callback
-    def _log_unavailable(
-        self, exception: Exception | None = None, prev_available: bool | None = None
-    ):
+    def _log_unavailable(self, exception: Exception | None = None):
         """Helper to log when unavailable."""
-        prev_available = (
-            prev_available if prev_available is not None else self._attr_available
-        )
         available = self._attr_available
+        prev_available = self._prev_available
+        self._prev_available = available
 
         # Log when the entity becomes unavailable
         if prev_available and not available:
+            _LOGGER.info("Entity %s is unavailable", self.entity_id)
             _LOGGER.debug(
                 "    %s  =  UNAVAILABLE   from %s%s%s",
                 self.entity_id,
@@ -823,8 +821,16 @@ class ZaptecBaseEntity(CoordinatorEntity[ZaptecUpdateCoordinator]):
 
             # Dump the exception if present - not interested in KeyUnavailableError
             # since the TB is expected when the key is not available.
-            if exception is not None and not isinstance(exception, KeyUnavailableError):
+            if (
+                exception is not None
+                and not isinstance(exception, KeyUnavailableError)
+                and self.key not in KEYS_TO_SKIP_ENTITY_AVAILABILITY_CHECK
+            ):
                 _LOGGER.error("Getting value failed", exc_info=exception)
+
+        # Log when the entity becomes available again
+        elif not prev_available and available:
+            _LOGGER.info("Entity %s is available", self.entity_id)
 
     @property
     def key(self):

--- a/custom_components/zaptec/const.py
+++ b/custom_components/zaptec/const.py
@@ -81,3 +81,9 @@ CHARGER_EXCLUDES = {
     "900",  # ProductionTestResults
     "980",  # MIDCalibration
 }
+
+# These keys will not be checked at startup for entity availability. This is
+# useful for keys that are not always present in the API response, such as
+KEYS_TO_SKIP_ENTITY_AVAILABILITY_CHECK = {
+    "total_charge_power_session",
+}


### PR DESCRIPTION
It turns out that some Zaptec attributes are not always present from Zaptec. An example is "total_charge_power_session". The recommendation from HA is to not add entities that aren't available, but we have to circumvent that in this case. Instead a setting have been added so it can be later turned on if wanted.

Fixes #217