### PR TITLE
Fixed incorrect sleep interval

### DIFF
--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -970,7 +970,7 @@ class Zaptec(Mapping[str, ZaptecBase]):
                 if sleep_delay > 0:
                     if DEBUG_API_CALLS:
                         _LOGGER.debug("Sleeping for %1.1f seconds", sleep_delay)
-                    await asyncio.sleep(delay)
+                    await asyncio.sleep(sleep_delay)
 
             # Exceptions that can be retried
             except (asyncio.TimeoutError, aiohttp.ClientConnectionError) as err:


### PR DESCRIPTION
This PR fixes where the sleep function on request retry sleeps the wrong time (too long).