### PR TITLE
Add logging of all attributes during startup

### DIFF
--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -218,6 +218,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Done setting up, change back to not log all updates. Having this enabled
     # will create a lot of debug log output.
     zaptec.show_all_updates = False
+    _LOGGER.debug("Zaptec setup complete")
 
     # Attach the local data to the HA config entry so it can be accessed later
     # in various HA functions.

--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -118,6 +118,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data[CONF_PASSWORD],
         client=async_get_clientsession(hass),
         max_time=ZAPTEC_POLL_INTERVAL_CHARGING,  # The shortest of the intervals
+        show_all_updates=True,  # During setup we'd like to log all updates
     )
 
     # Login to the Zaptec account
@@ -213,6 +214,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Initialize the coordinators
     for co in manager.all_coordinators:
         await co.async_config_entry_first_refresh()
+
+    # Done setting up, change back to not log all updates. Having this enabled
+    # will create a lot of debug log output.
+    zaptec.show_all_updates = False
 
     # Attach the local data to the HA config entry so it can be accessed later
     # in various HA functions.

--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -171,7 +171,7 @@ class ZaptecBase(Mapping[str, TValue]):
             new_vt = type(new_v).__qualname__
             if new_key not in self._attrs:
                 _LOGGER.debug(
-                    ">>>  Adding %s.%s (%s)  =  <%s> %s",
+                    ">>>  Adding   %s.%s (%s)  =  <%s> %s",
                     self.qual_id,
                     new_key,
                     k,
@@ -187,6 +187,15 @@ class ZaptecBase(Mapping[str, TValue]):
                     new_vt,
                     repr(new_v),
                     self._attrs[new_key],
+                )
+            elif self.zaptec.show_all_updates:
+                _LOGGER.debug(
+                    ">>>  Ignoring %s.%s (%s)  =  <%s> %s  (no change)",
+                    self.qual_id,
+                    new_key,
+                    k,
+                    new_vt,
+                    repr(new_v),
                 )
             self._attrs[new_key] = new_v
 
@@ -800,6 +809,7 @@ class Zaptec(Mapping[str, ZaptecBase]):
         *,
         client: aiohttp.ClientSession | None = None,
         max_time: float = API_RETRY_MAXTIME,
+        show_all_updates: bool = False,
     ) -> None:
         """Initialize the Zaptec account handler."""
         self._username = username
@@ -817,6 +827,9 @@ class Zaptec(Mapping[str, ZaptecBase]):
 
         self.is_built: bool = False
         """Flag to indicate if the structure of objectes is built and ready to use."""
+
+        self.show_all_updates: bool = show_all_updates
+        """Flag to indicate if all updates should be logged, even if no changes."""
 
     async def __aenter__(self) -> Zaptec:
         """Enter the context manager."""


### PR DESCRIPTION
During startup, the debug list of all attributes returned from Zaptec is useful to establish the origin of the attributes. Many attributes are provided by multiple requests and this information was omitted. By enabling this flag, the debug output will now print the update of the attribute, even if it doesn't change.

This flag is enabled during startup of the integration, and turned off when everything has been discovered

* Add `Zaptec.show_all_updates` flag to enable/disable the function
* Enable the flag dusring loading and disable it when setup is complete