### PR TITLE
Update devcontainer to latest debian version

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Zaptec integration development",
-    "image": "mcr.microsoft.com/vscode/devcontainers/python:3.13-bullseye",
+    "image": "mcr.microsoft.com/vscode/devcontainers/python:3.13-bookworm",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [
         8123


### PR DESCRIPTION
Main reason for updating is to get SQLite 3.40.1 (old version had 3.34.1). This was preventing the recorder setup, which in turn prevented the setup of energy, history and logbook and the installation of any integration relying on any of them (for instance the tibber-integration).