### PR TITLE
Use state value for authorization required for more frequent updates

### DIFF
--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -283,6 +283,14 @@ def remove_deprecated_entities(hass: HomeAssistant, entry: ZaptecConfigEntry) ->
             # before the new ones are added.
             _LOGGER.warning("Removing deprecated entity: %s", entity_id)
             entity_registry.async_remove(entity_id)
+        elif entity.unique_id.endswith("_is_authorization_required"):
+            # There is an entity using authorization_required as a translation key in
+            # both the installation and the charger device. We only want to replace the
+            # entity associated with the charger, so we use the end of the unique_id
+            # to find the correct entity that will be readded later (the installation
+            # entity ends with '_is_required_authentication').
+            _LOGGER.warning("Removing deprecated entity: %s", entity_id)
+            entity_registry.async_remove(entity_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ZaptecConfigEntry) -> bool:

--- a/custom_components/zaptec/binary_sensor.py
+++ b/custom_components/zaptec/binary_sensor.py
@@ -90,7 +90,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         cls=ZaptecBinarySensor,
     ),
     ZapBinarySensorEntityDescription(
-        key="is_authorization_required",
+        key="authentication_required",
         translation_key="authorization_required",
         entity_category=const.EntityCategory.DIAGNOSTIC,
         icon="mdi:lock",


### PR DESCRIPTION
Use `authentication_required` instead of `is_authorization_required` since that is part of the state update.

Fixes (part of) #219