### PR TITLE
Leak less usernames and UID into the logs

### DIFF
--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -205,7 +205,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry=entry,
             manager=manager,
             options=ZaptecUpdateOptions(
-                name=deviceid,
+                name=zaptec_obj.qual_id,
                 update_interval=ZAPTEC_POLL_INTERVAL_IDLE,
                 charging_update_interval=charging_update_interval,
                 tracked_devices={deviceid},  # One device per coordinator
@@ -562,7 +562,7 @@ class ZaptecUpdateCoordinator(DataUpdateCoordinator[None]):
             hass,
             _LOGGER,
             config_entry=entry,
-            name=f"{DOMAIN}-{entry.data['username']}-{options.name}",
+            name=f"{DOMAIN}-{options.name.lower()}",
             update_interval=self._default_update_interval,
             request_refresh_debouncer=Debouncer(
                 hass,
@@ -606,8 +606,7 @@ class ZaptecUpdateCoordinator(DataUpdateCoordinator[None]):
         """Poll data from Zaptec."""
 
         try:
-            name = self.zaptec.qual_id(self.options.name)
-            _LOGGER.debug("--- Polling %s from Zaptec", name)
+            _LOGGER.debug("--- Polling %s from Zaptec", self.options.name)
             await self.zaptec.poll(
                 self.options.tracked_devices,
                 **self.options.poll_args,


### PR DESCRIPTION
This minor PR ensure there is less logging of long UID and user-names in the logs by renaming the coordinators.

It changes

```
# FROM
[custom_components.zaptec] Finished fetching zaptec-my@user.com-12345678-2222-7777-5555-000000040861 data in 0.124 seconds (success: True)

# TO
[custom_components.zaptec] Finished fetching zaptec-charger[f40861] data in 0.124 seconds (success: True)
```
