### PR TITLE
Precompile regexp for performance

### DIFF
--- a/custom_components/zaptec/misc.py
+++ b/custom_components/zaptec/misc.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 import re
 
 
+# Precompile the patterns for performance
+RE_TO_UNDER1 = re.compile(r"([A-Z]+)([A-Z][a-z])")
+RE_TO_UNDER2 = re.compile(r"([a-z\d])([A-Z])")
+
+
 def to_under(word: str) -> str:
     """helper to convert TurnOnThisButton to turn_on_this_button."""
     # Ripped from inflection
-    word = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", word)
-    word = re.sub(r"([a-z\d])([A-Z])", r"\1_\2", word)
+    word = RE_TO_UNDER1.sub(r"\1_\2", word)
+    word = RE_TO_UNDER2.sub(r"\1_\2", word)
     word = word.replace("-", "_")
     return word.lower()
 


### PR DESCRIPTION
I discovered this goodie while testing. `to_under()` is used quite frequently across the code, so having it to compile two regexps each time is not efficient.
