### PR TITLE
Replace unavailable common string-keys with the translated strings

### DIFF
--- a/custom_components/zaptec/translations/en.json
+++ b/custom_components/zaptec/translations/en.json
@@ -23,8 +23,8 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error",
-            "no_chargers_selected": "No chargers selected. Please select at least one charger."
+            "no_chargers_selected": "No chargers selected. Please select at least one charger.",
+            "unknown": "Unexpected error"
         },
         "abort":{
             "already_exists": "One instance of Zaptec already exists."

--- a/custom_components/zaptec/translations/nl.json
+++ b/custom_components/zaptec/translations/nl.json
@@ -23,8 +23,8 @@
         "error": {
             "cannot_connect": "Kan geen verbinding maken",
             "invalid_auth": "Ongeldige authenticatie",
-            "unknown": "Onverwachte fout",
-            "no_chargers_selected": "Geen oplader(s) geselecteerd. Selecteer ten minste één oplader."
+            "no_chargers_selected": "Geen oplader(s) geselecteerd. Selecteer ten minste één oplader.",
+            "unknown": "Onverwachte fout"
         },
         "abort":{
             "already_exists": "Een exemplaar van Zaptec bestaat al."

--- a/custom_components/zaptec/translations/pl.json
+++ b/custom_components/zaptec/translations/pl.json
@@ -23,8 +23,8 @@
         "error": {
             "cannot_connect": "Nie mo\u017cna nawi\u0105za\u0107 po\u0142\u0105czenia",
             "invalid_auth": "Niepoprawne uwierzytelnienie",
-            "unknown": "Nieoczekiwany b\u0142\u0105d",
-            "no_chargers_selected": "Nie wybrano ładowarek. Wybierz co najmniej jedną ładowarkę."
+            "no_chargers_selected": "Nie wybrano ładowarek. Wybierz co najmniej jedną ładowarkę.",
+            "unknown": "Nieoczekiwany b\u0142\u0105d"
         },
         "abort":{
             "already_exists": "Istnieje już jedna instancja Zaptec."

--- a/custom_components/zaptec/translations/sv.json
+++ b/custom_components/zaptec/translations/sv.json
@@ -23,8 +23,8 @@
         "error": {
             "cannot_connect": "Det gick inte att ansluta",
             "invalid_auth": "Ogiltig autentisering",
-            "unknown": "Ov\u00e4ntat fel",
-            "no_chargers_selected": "Ingen laddare vald. Välj minst en laddare."
+            "no_chargers_selected": "Ingen laddare vald. Välj minst en laddare.",
+            "unknown": "Ov\u00e4ntat fel"
         },
         "abort":{
             "already_exists": "En instans med laddare finns redan."


### PR DESCRIPTION
Only core components can use these standard texts: https://developers.home-assistant.io/docs/internationalization/custom_integration/

(translations collected from [airnow component last commit before translations were removed from core](https://github.com/home-assistant/core/tree/4ad386d7941ba0bc6cec7674f3fea85357194f8b/homeassistant/components/airnow/translations) )

Fixes #242