### PR TITLE
Update dev container with latest reference

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Zaptec integration development",
-    "image": "mcr.microsoft.com/vscode/devcontainers/python:3.13-bookworm",
+    "image": "mcr.microsoft.com/devcontainers/python:3.13",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [
         8123
@@ -9,46 +9,45 @@
         "8123": {
             "label": "Home Assistant",
             "onAutoForward": "notify"
-        },
-        "0-8122": {
-            "label": "Auto-Forwarded - Other",
-            "onAutoForward": "ignore"
-        },
-        "8124-999999": {
-            "label": "Auto-Forwarded - Other",
-            "onAutoForward": "ignore"
         }
     },
     "customizations": {
         "vscode": {
             "extensions": [
-                "ms-python.python",
+                "charliermarsh.ruff",
                 "github.vscode-pull-request-github",
-                "ryanluker.vscode-coverage-gutters",
+                "ms-python.python",
                 "ms-python.vscode-pylance",
-                "visualstudioexptteam.vscodeintellicode",
-                "redhat.vscode-yaml",
-                "esbenp.prettier-vscode"
+                "ryanluker.vscode-coverage-gutters",
+                "visualstudioexptteam.vscodeintellicode"
             ],
             "settings": {
-                "files.eol": "\n",
-                "editor.tabSize": 4,
-                "python.defaultInterpreterPath": "/usr/local/bin/python",
-                "python.pythonPath": "/usr/local/python/bin/python",
-                "python.analysis.autoSearchPaths": false,
-                "python.linting.pylintEnabled": true,
-                "python.linting.enabled": true,
-                "python.formatting.provider": "black",
-                "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+                "[python]": {
+                    "editor.defaultFormatter": "charliermarsh.ruff"
+                },
                 "editor.formatOnPaste": false,
-                "editor.formatOnSave": false,
+                "editor.formatOnSave": true,
                 "editor.formatOnType": true,
-                "files.trimTrailingWhitespace": true
+                "editor.tabSize": 4,
+                "files.eol": "\n",
+                "files.trimTrailingWhitespace": true,
+                "python.analysis.autoImportCompletions": true,
+                "python.analysis.extraPaths": [
+                    "/home/vscode/.local/lib/python3.13/site-packages"
+                ],
+                "python.analysis.typeCheckingMode": "basic",
+                "python.defaultInterpreterPath": "/usr/local/bin/python"
             }
         }
     },
     "remoteUser": "vscode",
     "features": {
-        "rust": "latest"
+        "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+            "packages": [
+                "ffmpeg",
+                "libturbojpeg0",
+                "libpcap-dev"
+            ]
+        }
     }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,17 +1,2 @@
-# Auto detect text files and perform LF normalization
-* text=auto
-
-# Custom for Visual Studio
-*.cs     diff=csharp
-
-# Standard to msysgit
-*.doc	 diff=astextplain
-*.DOC	 diff=astextplain
-*.docx diff=astextplain
-*.DOCX diff=astextplain
-*.dot  diff=astextplain
-*.DOT  diff=astextplain
-*.pdf  diff=astextplain
-*.PDF	 diff=astextplain
-*.rtf	 diff=astextplain
-*.RTF	 diff=astextplain
+* text=auto eol=lf
+*.py  whitespace=error

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,32 @@
+name: Validate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions: {}
+
+jobs:
+  hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest
+    name: Hassfest validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Run hassfest validation
+        uses: home-assistant/actions/hassfest@master
+
+  hacs: # https://github.com/hacs/action
+    name: HACS validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/.gitignore
+++ b/.gitignore
@@ -1,33 +1,31 @@
-# Windows thumbnail cache files
-Thumbs.db
-ehthumbs.db
-ehthumbs_vista.db
-
-# Folder config file
-Desktop.ini
-
-# Recycle Bin used on file shares
-$RECYCLE.BIN/
-
-# Windows Installer files
-*.cab
-*.msi
-*.msm
-*.msp
-
-# Windows shortcuts
-*.lnk
-
-# Python files
+# artifacts
 __pycache__
+.pytest*
+*.egg-info
+*/build/*
+*/dist/*
 
-# Python virtual environments
-venv*/
-/.python-version
+# misc
+.coverage
+.vscode
+coverage.xml
+.ruff_cache
 
 # Home Assistant configuration
 config/*
 !config/configuration.yaml
+
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# Python virtual environments
+venv*/
+.venv*/
+/.python-version
 
 # Zaptec files
 constant.json

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,25 @@
+# The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
+
+target-version = "py313"
+
+[lint]
+select = [
+    "ALL",
+]
+
+ignore = [
+    "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
+    "D203", # no-blank-line-before-class (incompatible with formatter)
+    "D212", # multi-line-summary-first-line (incompatible with formatter)
+    "COM812", # incompatible with formatter
+    "ISC001", # incompatible with formatter
+]
+
+[lint.flake8-pytest-style]
+fixture-parentheses = false
+
+[lint.pyupgrade]
+keep-runtime-typing = true
+
+[lint.mccabe]
+max-complexity = 25

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,10 +1,21 @@
-default_config:
+# This provides the default setup, but it also requires some packages that are
+# not available in the dev container. It can be commented out, but some
+# functionality of HA won't be initialized yet.
+# https://www.home-assistant.io/integrations/default_config/
+# default_config:
 
+# Alternatives instead of using default_config
+config:
+energy:
+mobile_app:
+
+# https://www.home-assistant.io/integrations/homeassistant/
+homeassistant:
+  debug: true
+
+# https://www.home-assistant.io/integrations/logger/
 logger:
   default: info
   logs:
     custom_components.zaptec: debug
-    custom_components.zaptec.api: debug
-
-# If you need to debug uncomment the line below (doc: https://www.home-assistant.io/integrations/debugpy/)
-# debugpy:
+    azure.servicebus: warning

--- a/custom_components/zaptec/manifest.json
+++ b/custom_components/zaptec/manifest.json
@@ -1,14 +1,16 @@
 {
   "domain": "zaptec",
   "name": "Zaptec EV charger",
-  "documentation": "https://github.com/custom-components/zaptec",
-  "dependencies": [],
-  "config_flow": true,
   "codeowners": [
-    "hellowlol",
-    "sveinse"
+    "@sveinse",
+    "@hellowlol"
   ],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/custom-components/zaptec",
+  "integration_type": "hub",
   "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/custom-components/zaptec/issues",
   "requirements": ["azure-servicebus==7.14.2", "pydantic==2.11.7", "aiolimiter==1.2.1"],
   "version": "0.8b1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
     "name": "Zaptec EV charger",
-    "render_readme": true
+    "homeassistant": "2025.2.4",
+    "hacs": "2.0.5",
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 colorlog==6.9.0
-homeassistant==2025.6.3
-pip>=25.0,<25.2
-ruff==0.12.1
-bleak==0.22.3 # bleak 1.0.0 breaks habluetooth as of 2025.06.29, remove once https://github.com/Bluetooth-Devices/habluetooth/issues/248 is resolved
+homeassistant==2025.7.3
+pip>=21.31.1
+ruff==0.12.4

--- a/scripts/lint
+++ b/scripts/lint
@@ -4,4 +4,5 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+ruff format .
 ruff check . --fix

--- a/scripts/setup
+++ b/scripts/setup
@@ -4,14 +4,4 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-pip_packages() {
-    python3 -m pip \
-        install \
-        --upgrade \
-        --disable-pip-version-check \
-        "${@}"
-}
-
-pip_packages "pip<25.2,>=25.0.0"
-pip_packages setuptools wheel
-pip_packages --requirement requirements.txt
+python3 -m pip install --requirement requirements.txt


### PR DESCRIPTION
This is an overhaul of the dev-container setup. It updates the development environment for this integration, putting us closer to the HA standard. It takes inspiration from https://github.com/ludeeus/integration_blueprint and from https://github.com/home-assistant/core. This is pt1 of #185. Pt2 is the actual documentation which I'm working on.

This has been tested on a fresh machine. HA starts fine with not that many errors, and intellisense lookup of the HA classes now work in the dev container. It changes linter to ruff, which is the standard in HA now.

* Update package setup (missing field)
* Setup automatic GitHub Actions for validation
* Change to ruff and set defaults
* Force line endings to LF and prevent commits with incorrect spacing