### PR TITLE
Updated ruff settings and fixed the simplest errors in the code

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,18 +1,27 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
 target-version = "py313"
+line-length = 98
 
 [lint]
 select = [
     "ALL",
 ]
 
+# Here we specify the rules we want to ignore. Its fully possible to add more
+# rules here if necessary. If in doubt, please check the Home Assistant
+# rule list. If they use excepmt for a rule, we should use it too.
+#   https://github.com/home-assistant/core/blob/dev/pyproject.toml#L652
 ignore = [
     "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
-    "D203", # no-blank-line-before-class (incompatible with formatter)
-    "D212", # multi-line-summary-first-line (incompatible with formatter)
     "COM812", # incompatible with formatter
+    "D202",   # No blank lines allowed after function docstring
+    "D203",   # no-blank-line-before-class (incompatible with formatter)
+    "D212",   # multi-line-summary-first-line (incompatible with formatter)
+    "D213",   # Multi-line docstring summary should start at the second line
     "ISC001", # incompatible with formatter
+    "TRY003", # Avoid specifying long messages outside the exception class
+    "TRY400", # Use `logging.exception` instead of `logging.error`
 ]
 
 [lint.flake8-pytest-style]

--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -270,13 +270,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 def remove_deprecated_entities(hass: HomeAssistant, entry: ZaptecConfigEntry) -> None:
-    """Remove deprecated entites from the entity_registry"""
+    """Remove deprecated entites from the entity_registry."""
 
     entity_registry = er.async_get(hass)
-    zaptec_entity_list = [(entity_id, entity) for entity_id, entity in list(
-        entity_registry.entities.items()) if entity.config_entry_id == entry.entry_id]
+    zaptec_entity_list = [
+        (entity_id, entity)
+        for entity_id, entity in list(entity_registry.entities.items())
+        if entity.config_entry_id == entry.entry_id
+    ]
     for entity_id, entity in zaptec_entity_list:
-        if entity.translation_key == 'operating_mode':
+        if entity.translation_key == "operating_mode":
             # Needed for v0.7 -> v0.8 upgrade
             # The two entities this applies to were changed to the key
             # charger_operation_mode (from state) instead of operating_mode (from info).
@@ -506,9 +509,7 @@ class ZaptecManager:
         coordinator.async_update_listeners()
 
     @staticmethod
-    async def first_time_setup(
-        zaptec: Zaptec, configured_chargers: set[str] | None
-    ) -> set[str]:
+    async def first_time_setup(zaptec: Zaptec, configured_chargers: set[str] | None) -> set[str]:
         """Run the first time setup for the account."""
         _LOGGER.debug("Running first time setup")
 
@@ -622,9 +623,7 @@ class ZaptecUpdateCoordinator(DataUpdateCoordinator[None]):
                 **self.options.poll_args,
             )
         except ZaptecApiError as err:
-            _LOGGER.exception(
-                "Fetching data failed: %s: %s", type(err).__qualname__, err
-            )
+            _LOGGER.exception("Fetching data failed: %s: %s", type(err).__qualname__, err)
             raise UpdateFailed(err) from err
 
     async def _trigger_poll(self, zaptec_obj: ZaptecBase) -> None:
@@ -647,9 +646,7 @@ class ZaptecUpdateCoordinator(DataUpdateCoordinator[None]):
         else:
             delays = ZAPTEC_POLL_CHARGER_TRIGGER_DELAYS
 
-        _LOGGER.debug(
-            "Triggering poll of %s after %s seconds", zaptec_obj.qual_id, delays
-        )
+        _LOGGER.debug("Triggering poll of %s after %s seconds", zaptec_obj.qual_id, delays)
 
         # Calculcate the deltas for the delays. E.g. [2, 5, 10] -> [2, 3, 5]
         deltas = [b - a for a, b in zip([0] + delays[:-1], delays)]

--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -9,7 +9,7 @@ import json
 import logging
 import random
 import time
-from typing import Any, Protocol
+from typing import Any, ClassVar, Protocol
 
 import aiohttp
 from aiolimiter import AsyncLimiter
@@ -95,7 +95,7 @@ class ZaptecBase(Mapping[str, TValue]):
     """Base class for Zaptec objects."""
 
     # Type definitions and convertions on the attributes
-    ATTR_TYPES: dict[str, Callable] = {}
+    ATTR_TYPES: ClassVar[dict[str, Callable]] = {}
 
     def __init__(self, data: TDict, zaptec: Zaptec) -> None:
         """Initialize the ZaptecBase object."""
@@ -144,10 +144,10 @@ class ZaptecBase(Mapping[str, TValue]):
     #   UPDATE METHODS
 
     async def poll_info(self) -> None:
-        """Poll information about the object"""
+        """Poll information about the object."""
 
     async def poll_state(self) -> None:
-        """Poll the state of the object"""
+        """Poll the state of the object."""
 
     def set_attributes(self, data: TDict) -> bool:
         """Set the class attributes from the given data."""
@@ -224,9 +224,7 @@ class ZaptecBase(Mapping[str, TValue]):
             if value is not MISSING:
                 kv = keydict.get(skey, f"{key} {skey}")
                 if kv in out:
-                    _LOGGER.debug(
-                        "Duplicate key %s. Is '%s', new '%s'", kv, out[kv], value
-                    )
+                    _LOGGER.debug("Duplicate key %s. Is '%s', new '%s'", kv, out[kv], value)
                 out[kv] = value
         return out
 
@@ -235,7 +233,7 @@ class Installation(ZaptecBase):
     """Represents an installation."""
 
     # Type conversions for the named attributes (keep sorted)
-    ATTR_TYPES = {
+    ATTR_TYPES: ClassVar[dict[str, Callable]] = {
         "active": bool,
         "authentication_type": ZCONST.type_authentication_type,
         "current_user_roles": ZCONST.type_user_roles,
@@ -314,9 +312,7 @@ class Installation(ZaptecBase):
         _LOGGER.debug("Poll firmware info from %s (%s)", self.qual_id, self.get("Name"))
 
         try:
-            firmware_info = await self.zaptec.request(
-                f"chargerFirmware/installation/{self.id}"
-            )
+            firmware_info = await self.zaptec.request(f"chargerFirmware/installation/{self.id}")
             for fm in firmware_info:
                 charger = self.zaptec.get(fm["ChargerId"])
                 if charger is None:
@@ -339,9 +335,7 @@ class Installation(ZaptecBase):
     async def live_stream_connection_details(self):
         """Get the live stream connection details for the installation."""
         # NOTE: API call deprecated
-        data = await self.zaptec.request(
-            f"installation/{self.id}/messagingConnectionDetails"
-        )
+        data = await self.zaptec.request(f"installation/{self.id}/messagingConnectionDetails")
         self.connection_details = data
         return data
 
@@ -355,9 +349,7 @@ class Installation(ZaptecBase):
             return None
 
         await self.cancel_stream()
-        self._stream_task = asyncio.create_task(
-            self.stream_main(cb=cb, ssl_context=ssl_context)
-        )
+        self._stream_task = asyncio.create_task(self.stream_main(cb=cb, ssl_context=ssl_context))
         return self._stream_task
 
     def _stream_log(self, data: dict[str, Any]) -> None:
@@ -382,9 +374,7 @@ class Installation(ZaptecBase):
             try:
                 from azure.servicebus.aio import ServiceBusClient
             except ImportError:
-                _LOGGER.warning(
-                    "Azure Service bus is not available. Resolving to polling"
-                )
+                _LOGGER.warning("Azure Service bus is not available. Resolving to polling")
                 return
 
             # Already running?
@@ -414,9 +404,7 @@ class Installation(ZaptecBase):
             kw = {}
             if ssl_context:
                 kw["ssl_context"] = ssl_context
-            servicebus_client = ServiceBusClient.from_connection_string(
-                conn_str=constr, **kw
-            )
+            servicebus_client = ServiceBusClient.from_connection_string(conn_str=constr, **kw)
             obfuscated = constr.replace(conf["Password"], "********").replace(
                 conf["Username"], "********"
             )
@@ -464,9 +452,7 @@ class Installation(ZaptecBase):
                                 await cb(json_result)
 
                         except Exception as err:
-                            _LOGGER.exception(
-                                "Couldn't process stream message: %s", err
-                            )
+                            _LOGGER.exception("Couldn't process stream message: %s", err)
                             _LOGGER.debug("Message: %s", binmsg)
                             # Pass the message as the stream must continue.
 
@@ -566,7 +552,7 @@ class Charger(ZaptecBase):
     """Represents a charger."""
 
     # Type conversions for the named attributes (keep sorted)
-    ATTR_TYPES = {
+    ATTR_TYPES: ClassVar[dict[str, Callable]] = {
         "active": bool,
         "authentication_required": lambda x: x in TRUTHY,
         "authentication_type": ZCONST.type_authentication_type,
@@ -608,7 +594,7 @@ class Charger(ZaptecBase):
         self.installation = installation
 
     async def poll_info(self) -> None:
-        """Refresh the charger data"""
+        """Refresh the charger data."""
         _LOGGER.debug("Poll info from %s (%s)", self.qual_id, self.get("Name"))
 
         try:
@@ -629,7 +615,7 @@ class Charger(ZaptecBase):
                     break
 
     async def poll_state(self):
-        """Update the charger state"""
+        """Update the charger state."""
         _LOGGER.debug("Poll state from %s (%s)", self.qual_id, self.get("Name"))
 
         # Get the state from the charger
@@ -684,14 +670,10 @@ class Charger(ZaptecBase):
         self.is_command_valid(command, raise_value_error_if_invalid=True)
 
         _LOGGER.debug("Command %s (%s)", command, cmdid)
-        data = await self.zaptec.request(
-            f"chargers/{self.id}/SendCommand/{cmdid}", method="post"
-        )
+        data = await self.zaptec.request(f"chargers/{self.id}/SendCommand/{cmdid}", method="post")
         return data
 
-    def is_command_valid(
-        self, command: str, raise_value_error_if_invalid=False
-    ) -> bool:
+    def is_command_valid(self, command: str, raise_value_error_if_invalid=False) -> bool:
         """Check if the command is valid."""
 
         valid_command = True
@@ -701,12 +683,8 @@ class Charger(ZaptecBase):
             # commands 506+507 in https://api.zaptec.com/help/index.html#/Charger/Charger_SendCommand_POST
             operation_mode = self.get("ChargerOperationMode")
             final_stop_active = self.get("FinalStopActive")
-            paused = (
-                operation_mode == "Connected_Finished" and int(final_stop_active) == 1
-            )
-            if command == "stop_charging_final" and (
-                paused or operation_mode == "Disconnected"
-            ):
+            paused = operation_mode == "Connected_Finished" and int(final_stop_active) == 1
+            if command == "stop_charging_final" and (paused or operation_mode == "Disconnected"):
                 msg = "Pause/stop charging is not allowed if charging is already paused or disconnected"
                 valid_command = False
             elif command == "resume_charging" and not paused:
@@ -742,9 +720,7 @@ class Charger(ZaptecBase):
         """Authorize the charger to charge."""
         _LOGGER.debug("Authorize charge")
         # NOTE: Undocumented API call
-        data = await self.zaptec.request(
-            f"chargers/{self.id}/authorizecharge", method="post"
-        )
+        data = await self.zaptec.request(f"chargers/{self.id}/authorizecharge", method="post")
         return data
 
     async def set_permanent_cable_lock(self, lock: bool):
@@ -852,8 +828,7 @@ class Zaptec(Mapping[str, ZaptecBase]):
         """Register an object data with id."""
         if id in self._map:
             raise ValueError(
-                f"Object with id {id} already registered. "
-                "Use unregister() to remove it first."
+                f"Object with id {id} already registered. Use unregister() to remove it first."
             )
         self._map[id] = data
 
@@ -943,7 +918,7 @@ class Zaptec(Mapping[str, ZaptecBase]):
 
         error: Exception | None = None
         delay: float = API_RETRY_INIT_DELAY
-        sleep_delay: float = 0.
+        sleep_delay: float = 0.0
         start_time: float = time.perf_counter()
         iteration = 0
         for iteration in range(1, retries + 1):
@@ -964,9 +939,10 @@ class Zaptec(Mapping[str, ZaptecBase]):
                 start_time = time.perf_counter()
 
                 # Make the request
-                async with self._ratelimiter, self._client.request(
-                        method=method, url=url, **kwargs
-                ) as response:
+                async with (
+                    self._ratelimiter,
+                    self._client.request(method=method, url=url, **kwargs) as response,
+                ):
                     # Log the response
                     log_resp = [m async for m in self._response_log(response)]
                     if DEBUG_API_CALLS:
@@ -1020,9 +996,7 @@ class Zaptec(Mapping[str, ZaptecBase]):
                 f"Request to {url} failed after {iteration} retries: {error}"
             ) from None
 
-        raise RequestRetryError(
-            f"Request to {url} failed after {iteration} retries"
-        ) from None
+        raise RequestRetryError(f"Request to {url} failed after {iteration} retries") from None
 
     async def login(self) -> None:
         """Login to the Zaptec API and get an access token."""
@@ -1161,6 +1135,7 @@ class Zaptec(Mapping[str, ZaptecBase]):
 
                 # All other error codes will be raised
                 raise log_exc(error)
+            return None  # Should not happen, but the linter likes it.
 
     # =======================================================================
     #   UPDATE METHODS
@@ -1205,14 +1180,10 @@ class Zaptec(Mapping[str, ZaptecBase]):
         new_chargers = {d["Id"] for d in chargers["Data"]}
         have_chargers = {c.id for c in self.chargers}
         if missing_chargers := (have_chargers - new_chargers):
-            _LOGGER.warning(
-                "These chargers are no longer available: %s", missing_chargers
-            )
+            _LOGGER.warning("These chargers are no longer available: %s", missing_chargers)
             _LOGGER.warning("To remove them, please restart the integration.")
         if extra_chargers := (new_chargers - have_chargers):
-            _LOGGER.warning(
-                "These standalone chargers will not be added: %s", extra_chargers
-            )
+            _LOGGER.warning("These standalone chargers will not be added: %s", extra_chargers)
 
         # Update the observation, settings and commands ids based on the
         # discovered device types.

--- a/custom_components/zaptec/config_flow.py
+++ b/custom_components/zaptec/config_flow.py
@@ -5,21 +5,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import voluptuous as vol
-
-from homeassistant.config_entries import (
-    SOURCE_RECONFIGURE,
-    ConfigFlow,
-    ConfigFlowResult,
-)
+from homeassistant.config_entries import SOURCE_RECONFIGURE, ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.selector import (
-    TextSelector,
-    TextSelectorConfig,
-    TextSelectorType,
-)
+from homeassistant.helpers.selector import TextSelector, TextSelectorConfig, TextSelectorType
+import voluptuous as vol
 
 from .api import (
     AuthenticationError,
@@ -135,9 +126,7 @@ class ZaptecFlowHandler(ConfigFlow, domain=DOMAIN):
             reload_even_if_entry_is_unchanged=False,
         )
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle a configuration flow initiated by the user."""
         errors: dict[str, str] = {}
 
@@ -245,9 +234,7 @@ class ZaptecFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         reauth_entry = self._get_reauth_entry()
 
-        _LOGGER.debug(
-            "async_step_reauth_confirm called with user_input: %s", user_input
-        )
+        _LOGGER.debug("async_step_reauth_confirm called with user_input: %s", user_input)
 
         if user_input is not None:
             entries = {

--- a/custom_components/zaptec/diagnostics.py
+++ b/custom_components/zaptec/diagnostics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import traceback
-from typing import Any, TypeVar, cast
+from typing import Any, ClassVar, TypeVar, cast
 
 # to Support running this as a script.
 if __name__ != "__main__":
@@ -32,7 +32,7 @@ class Redactor:
     """Class to handle redaction of sensitive data."""
 
     # Data fields that must be redacted from the output
-    REDACT_KEYS = [
+    REDACT_KEYS: ClassVar[list[str]] = [
         "Address",
         "ChargerId",
         "ChargerCurrentUserUuid",
@@ -63,7 +63,7 @@ class Redactor:
     ]
 
     # Never redact these words
-    NEVER_REDACT = [
+    NEVER_REDACT: ClassVar[list] = [
         None,
         True,
         False,
@@ -82,11 +82,11 @@ class Redactor:
     ]
 
     # Keys that will be looked up into the observer id dict
-    OBS_KEYS = ["SettingId", "StateId"]
+    OBS_KEYS: ClassVar[list[str]] = ["SettingId", "StateId"]
 
     # Key names that will be redacted if they the dict has a OBS_KEY entry
     # and it is in the REDACT_KEYS list.
-    VALUES = [
+    VALUES: ClassVar[list[str]] = [
         "Value",
         "ValueAsString",
     ]
@@ -110,6 +110,7 @@ class Redactor:
 
     def redact(self, obj: T, ctx=None, key=None, secondpass=False) -> T:
         """Redact the object if it is present in the redacted dict.
+
         A new redaction is created if make_new is not None. ctx is
         for logging output.
         """
@@ -314,9 +315,7 @@ async def _get_diagnostics(
             device_registry, config_entry_id=config_entry.entry_id
         ):
             for _, zap_dev_id in dev.identifiers:
-                entity_list = device_map.setdefault(
-                    red.redact(zap_dev_id, ctx="entities"), []
-                )
+                entity_list = device_map.setdefault(red.redact(zap_dev_id, ctx="entities"), [])
 
                 dev_entities = er.async_entries_for_device(
                     entity_registry, dev.id, include_disabled_entities=True

--- a/custom_components/zaptec/misc.py
+++ b/custom_components/zaptec/misc.py
@@ -1,8 +1,8 @@
 """Misc helper stuff."""
+
 from __future__ import annotations
 
 import re
-
 
 # Precompile the patterns for performance
 RE_TO_UNDER1 = re.compile(r"([A-Z]+)([A-Z][a-z])")
@@ -10,7 +10,7 @@ RE_TO_UNDER2 = re.compile(r"([a-z\d])([A-Z])")
 
 
 def to_under(word: str) -> str:
-    """helper to convert TurnOnThisButton to turn_on_this_button."""
+    """Helper to convert TurnOnThisButton to turn_on_this_button."""
     # Ripped from inflection
     word = RE_TO_UNDER1.sub(r"\1_\2", word)
     word = RE_TO_UNDER2.sub(r"\1_\2", word)
@@ -100,11 +100,8 @@ def get_ocmf_max_reader_value(data: dict) -> float:
     """Return the maximum reader value from OCMF data."""
 
     if not isinstance(data, dict):
-        return 0.
-    return max(
-        float(reading.get("RV", 0.))
-        for reading in data.get("RD",[])
-    )
+        return 0.0
+    return max(float(reading.get("RV", 0.0)) for reading in data.get("RD", []))
 
 
 if __name__ == "__main__":

--- a/custom_components/zaptec/number.py
+++ b/custom_components/zaptec/number.py
@@ -78,9 +78,7 @@ class ZaptecSettingNumber(ZaptecNumber):
         # Get the max current rating from the reported max current
         self.entity_description = replace(
             self.entity_description,
-            native_max_value=self.zaptec_obj.get(
-                "ChargeCurrentInstallationMaxLimit", 32
-            ),
+            native_max_value=self.zaptec_obj.get("ChargeCurrentInstallationMaxLimit", 32),
         )
 
     async def async_set_native_value(self, value: float) -> None:

--- a/custom_components/zaptec/sensor.py
+++ b/custom_components/zaptec/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+from typing import ClassVar
 
 from homeassistant import const
 from homeassistant.components.sensor import (
@@ -43,7 +44,7 @@ class ZaptecChargeSensor(ZaptecSensor):
     _log_attribute = "_attr_native_value"
 
     # See ZCONST.charger_operation_modes for possible values
-    CHARGE_MODE_ICON_MAP = {
+    CHARGE_MODE_ICON_MAP: ClassVar[dict[str, str]] = {
         "Unknown": "mdi:help-rhombus-outline",
         "Disconnected": "mdi:power-plug-off",
         "Connected_Requesting": "mdi:timer-sand",

--- a/custom_components/zaptec/services.py
+++ b/custom_components/zaptec/services.py
@@ -6,18 +6,17 @@ from collections.abc import Awaitable, Callable, Generator
 import logging
 from typing import TYPE_CHECKING, TypeVar
 
-import voluptuous as vol
-
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 
 from .api import Charger, Installation
 from .const import DOMAIN
 
 if TYPE_CHECKING:
-    from . import ZaptecUpdateCoordinator, ZaptecManager
+    from . import ZaptecManager, ZaptecUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -157,9 +156,7 @@ async def async_setup_services(hass: HomeAssistant, manager: ZaptecManager) -> N
                 raise HomeAssistantError(f"Unable to find identifiers for {err_device}")
             for domain, uid in device_entry.identifiers:
                 if domain != DOMAIN:
-                    raise HomeAssistantError(
-                        f"Non-zaptec device specified {err_device}"
-                    )
+                    raise HomeAssistantError(f"Non-zaptec device specified {err_device}")
                 uids.add(uid)
                 lookup[uid] = err_device
 
@@ -187,9 +184,7 @@ async def async_setup_services(hass: HomeAssistant, manager: ZaptecManager) -> N
 
             zaptec_object = manager.zaptec.get(uid)
             if zaptec_object is None:
-                raise HomeAssistantError(
-                    f"Unable to find zaptec object for {err_device}"
-                )
+                raise HomeAssistantError(f"Unable to find zaptec object for {err_device}")
             if not isinstance(zaptec_object, mustbe):
                 raise HomeAssistantError(f"{err_device} is not a {mustbe.__name__}")
             if uid not in manager.device_coordinators:
@@ -209,9 +204,7 @@ async def async_setup_services(hass: HomeAssistant, manager: ZaptecManager) -> N
             try:
                 await obj.command("stop_charging_final")
             except Exception as exc:
-                raise HomeAssistantError(
-                    f"Command 'stop_charging_final' failed: {exc}"
-                ) from exc
+                raise HomeAssistantError(f"Command 'stop_charging_final' failed: {exc}") from exc
             await coordinator.trigger_poll()
 
     async def service_handle_resume_charging(service_call: ServiceCall) -> None:
@@ -225,9 +218,7 @@ async def async_setup_services(hass: HomeAssistant, manager: ZaptecManager) -> N
             try:
                 await obj.command("resume_charging")
             except Exception as exc:
-                raise HomeAssistantError(
-                    f"Command 'resume_charging' failed: {exc}"
-                ) from exc
+                raise HomeAssistantError(f"Command 'resume_charging' failed: {exc}") from exc
             await coordinator.trigger_poll()
 
     async def service_handle_authorize_charging(service_call: ServiceCall) -> None:
@@ -241,9 +232,7 @@ async def async_setup_services(hass: HomeAssistant, manager: ZaptecManager) -> N
             try:
                 await obj.authorize_charge()
             except Exception as exc:
-                raise HomeAssistantError(
-                    f"Command 'authorize_charge' failed: {exc}"
-                ) from exc
+                raise HomeAssistantError(f"Command 'authorize_charge' failed: {exc}") from exc
             await coordinator.trigger_poll()
 
     async def service_handle_deauthorize_charging(service_call: ServiceCall) -> None:
@@ -257,9 +246,7 @@ async def async_setup_services(hass: HomeAssistant, manager: ZaptecManager) -> N
             try:
                 await obj.command("deauthorize_and_stop")
             except Exception as exc:
-                raise HomeAssistantError(
-                    f"Command 'deauthorize_and_stop' failed: {exc}"
-                ) from exc
+                raise HomeAssistantError(f"Command 'deauthorize_and_stop' failed: {exc}") from exc
             await coordinator.trigger_poll()
 
     async def service_handle_restart_charger(service_call: ServiceCall) -> None:
@@ -273,9 +260,7 @@ async def async_setup_services(hass: HomeAssistant, manager: ZaptecManager) -> N
             try:
                 await obj.command("restart_charger")
             except Exception as exc:
-                raise HomeAssistantError(
-                    f"Command 'restart_charger' failed: {exc}"
-                ) from exc
+                raise HomeAssistantError(f"Command 'restart_charger' failed: {exc}") from exc
             await coordinator.trigger_poll()
 
     async def service_handle_upgrade_firmware(service_call: ServiceCall) -> None:
@@ -289,9 +274,7 @@ async def async_setup_services(hass: HomeAssistant, manager: ZaptecManager) -> N
             try:
                 await obj.command("upgrade_firmware")
             except Exception as exc:
-                raise HomeAssistantError(
-                    f"Command 'upgrade_firmware' failed: {exc}"
-                ) from exc
+                raise HomeAssistantError(f"Command 'upgrade_firmware' failed: {exc}") from exc
             await coordinator.trigger_poll()
 
     async def service_handle_limit_current(service_call: ServiceCall) -> None:

--- a/custom_components/zaptec/update.py
+++ b/custom_components/zaptec/update.py
@@ -35,12 +35,8 @@ class ZaptecUpdate(ZaptecBaseEntity, UpdateEntity):
     def _update_from_zaptec(self) -> None:
         """Update the entity from Zaptec data."""
         # Called from ZaptecBaseEntity._handle_coordinator_update()
-        self._attr_installed_version = self._get_zaptec_value(
-            key="firmware_current_version"
-        )
-        self._attr_latest_version = self._get_zaptec_value(
-            key="firmware_available_version"
-        )
+        self._attr_installed_version = self._get_zaptec_value(key="firmware_current_version")
+        self._attr_latest_version = self._get_zaptec_value(key="firmware_available_version")
         self._attr_available = True
 
     async def async_install(self, version, backup, **kwargs):

--- a/custom_components/zaptec/validate.py
+++ b/custom_components/zaptec/validate.py
@@ -1,4 +1,5 @@
 """Data validator for Zaptec API data."""
+
 from __future__ import annotations
 
 import logging
@@ -13,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class TypeWrapper:
-    """Workaround class for v1 pydantic"""
+    """Workaround class for v1 pydantic."""
 
 
 class Installation(BaseModel):

--- a/custom_components/zaptec/zconst.py
+++ b/custom_components/zaptec/zconst.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import UserDict
 import json
 import logging
-from typing import Literal
+from typing import ClassVar, Literal
 
 from .misc import to_under
 
@@ -33,7 +33,7 @@ class ZConst(UserDict):
     commands: dict[str, int]
     """Mapping of command name to command id and id to name."""
 
-    update_params = [
+    update_params: ClassVar[list[str]] = [
         "maxChargeCurrent",
         "maxChargePhases",
         "minChargeCurrent",
@@ -44,12 +44,16 @@ class ZConst(UserDict):
     """Valid parameters for charger settings (`chargers/{id}/update`)."""
 
     def get_remap(self, wanted, device_types=None) -> dict:
-        """Parse the given zaptec constants record `CONST` and generate
+        """Parse the Zaptec constants and return a remap dict.
+
+        Parse the given zaptec constants record `CONST` and generate
         a remap dict for the given `wanted` keys. If `device_types` is
         specified, the entries for these device schemas will be merged
         with the main remap dict.
+
         Example:
             get_remap(["Observations", "ObservationIds"], [4])
+
         """
         ids = {}
         for k, v in self.items():
@@ -62,10 +66,7 @@ class ZConst(UserDict):
                         v2 = schema.get(want)
                         if v2 is None:
                             continue
-                        if (
-                            name in device_types
-                            or schema.get("DeviceType") in device_types
-                        ):
+                        if name in device_types or schema.get("DeviceType") in device_types:
                             ids.update(v2)
 
         # make the reverse lookup
@@ -73,14 +74,15 @@ class ZConst(UserDict):
         return ids
 
     def update_ids_from_schema(self, device_types):
-        """Update the observations, settings and command ids from the
+        """Update the id from a schema.
+
+        Read observations, settings and command ids from the
         given device types. This is used to update the ids when the
-        schema is updated."""
+        schema is updated.
+        """
 
         # Define the remaps
-        self.observations = self.get_remap(
-            ["Observations", "ObservationIds"], device_types
-        )
+        self.observations = self.get_remap(["Observations", "ObservationIds"], device_types)
         self.settings = self.get_remap(["Settings", "SettingIds"], device_types)
         self.commands = self.get_remap(["Commands", "CommandIds"], device_types)
 
@@ -94,22 +96,22 @@ class ZConst(UserDict):
     #
     @property
     def charger_operation_modes_list(self):
-        """Return a list of all charger operation modes"""
+        """Return a list of all charger operation modes."""
         return list(self.get("ChargerOperationModes", {}))
 
     @property
     def device_types_list(self):
-        """Return a list of all device types"""
+        """Return a list of all device types."""
         return list(self.get("DeviceTypes", {}))
 
     @property
     def installation_authentication_type_list(self):
-        """Return a list of all installation authentication types"""
+        """Return a list of all installation authentication types."""
         return list(self.get("InstallationAuthenticationType", {}))
 
     @property
     def installation_types_list(self):
-        """Return a list of all installation types"""
+        """Return a list of all installation types."""
         return list(self.get("InstallationTypes", {}))
 
     @property
@@ -121,39 +123,36 @@ class ZConst(UserDict):
     # ATTRIBUTE TYPE CONVERTERS
     #
     def type_authentication_type(self, v):
-        """Convert the authentication type to a string"""
-        modes = {
-            str(v): k for k, v in self.get("InstallationAuthenticationType", {}).items()
-        }
+        """Convert the authentication type to a string."""
+        modes = {str(v): k for k, v in self.get("InstallationAuthenticationType", {}).items()}
         return modes.get(str(v), str(v))
 
     def type_completed_session(self, data):
-        """Convert the CompletedSession to a dict"""
+        """Convert the CompletedSession to a dict."""
         data = json.loads(data)
         if "SignedSession" in data:
             data["SignedSession"] = self.type_ocmf(data["SignedSession"])
         return data
 
     def type_device_type(self, v):
-        """Convert the device type to a string"""
+        """Convert the device type to a string."""
         modes = {str(v): k for k, v in self.get("DeviceTypes", {}).items()}
         return modes.get(str(v), str(v))
 
     def type_installation_type(self, v):
-        """Convert the installation type to a string"""
+        """Convert the installation type to a string."""
         modes = {
-            str(v.get("Id")): v.get("Name")
-            for v in self.get("InstallationTypes", {}).values()
+            str(v.get("Id")): v.get("Name") for v in self.get("InstallationTypes", {}).values()
         }
         return modes.get(str(v), str(v))
 
     def type_network_type(self, v):
-        """Convert the network type to a string"""
+        """Convert the network type to a string."""
         modes = {str(v): k for k, v in self.get("NetworkTypes", {}).items()}
         return modes.get(str(v), str(v))
 
     def type_ocmf(self, data):
-        """Open Charge Metering Format (OCMF) type"""
+        """Open Charge Metering Format (OCMF) type."""
         # https://github.com/SAFE-eV/OCMF-Open-Charge-Metering-Format/blob/master/OCMF-en.md
         sects = data.split("|")
         if len(sects) not in (2, 3) or sects[0] != "OCMF":
@@ -162,12 +161,12 @@ class ZConst(UserDict):
         return data
 
     def type_charger_operation_mode(self, v):
-        """Convert the operation mode to a string"""
+        """Convert the operation mode to a string."""
         modes = {str(v): k for k, v in self.get("ChargerOperationModes", {}).items()}
         return modes.get(str(v), str(v))
 
     def type_user_roles(self, v):
-        """Convert the user roles to a string"""
+        """Convert the user roles to a string."""
         val = int(v)
         if not val:
             return "None"


### PR DESCRIPTION
This PR fixes the most low-hanging fruits of the lint errors in the code. The PR also configures a few exceptions to ruff, that are too strict. I've used HA as a template to guide what settings should be enabled or disabled.

There are more lint errors remaining, and when someone takes a stab at it, we should also continue to evaluate if the rule is valid or not. We should keep looking at the extensive HA setting to see if we should mirror HAs exception.