### PR TITLE
Feature add log redaction

### DIFF
--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -43,6 +43,8 @@ from .const import (
     KEYS_TO_SKIP_ENTITY_AVAILABILITY_CHECK,
     MANUFACTURER,
     MISSING,
+    REDACT_DUMP_ON_STARTUP,
+    REDACT_LOGS,
     REQUEST_REFRESH_DELAY,
     ZAPTEC_POLL_CHARGER_TRIGGER_DELAYS,
     ZAPTEC_POLL_INSTALLATION_TRIGGER_DELAYS,
@@ -123,6 +125,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         client=async_get_clientsession(hass),
         max_time=ZAPTEC_POLL_INTERVAL_CHARGING,  # The shortest of the intervals
         show_all_updates=True,  # During setup we'd like to log all updates
+        redact_logs=REDACT_LOGS,
     )
 
     # Login to the Zaptec account
@@ -223,6 +226,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # will create a lot of debug log output.
     zaptec.show_all_updates = False
     _LOGGER.debug("Zaptec setup complete")
+
+    # Dump the redaction database
+    if REDACT_LOGS and REDACT_DUMP_ON_STARTUP:
+        _LOGGER.debug("------  DO NOT PUBLISH THE FOLLOWING DATA  ------")
+        _LOGGER.debug("|  Redaction database:")
+        for line in manager.zaptec.redact.dumps().splitlines():
+            _LOGGER.debug("|  %s", line)
+        _LOGGER.debug("------  DO NOT PUBLISH THE ABOVE ^^^ DATA  ------")
 
     # Attach the local data to the HA config entry so it can be accessed later
     # in various HA functions.

--- a/custom_components/zaptec/api.py
+++ b/custom_components/zaptec/api.py
@@ -32,6 +32,7 @@ from .const import (
     TRUTHY,
 )
 from .misc import mc_nbfx_decoder, to_under
+from .redact import Redactor
 from .validate import validate
 from .zconst import CommandType, ZConst
 
@@ -152,6 +153,7 @@ class ZaptecBase(Mapping[str, TValue]):
 
     def set_attributes(self, data: TDict) -> bool:
         """Set the class attributes from the given data."""
+        redact = self.zaptec.redact
         for k, v in data.items():
             # Cast the value to the correct type
             new_key = to_under(k)
@@ -177,7 +179,7 @@ class ZaptecBase(Mapping[str, TValue]):
                     new_key,
                     k,
                     new_vt,
-                    repr(new_v),
+                    repr(redact(new_v, key=k)),
                 )
             elif self._attrs[new_key] != new_v:
                 _LOGGER.debug(
@@ -186,8 +188,8 @@ class ZaptecBase(Mapping[str, TValue]):
                     new_key,
                     k,
                     new_vt,
-                    repr(new_v),
-                    self._attrs[new_key],
+                    repr(redact(new_v, key=k)),
+                    redact(self._attrs[new_key], key=k),
                 )
             elif self.zaptec.show_all_updates:
                 _LOGGER.debug(
@@ -196,7 +198,7 @@ class ZaptecBase(Mapping[str, TValue]):
                     new_key,
                     k,
                     new_vt,
-                    repr(new_v),
+                    repr(redact(new_v, key=k)),
                 )
             self._attrs[new_key] = new_v
 
@@ -270,13 +272,17 @@ class Installation(ZaptecBase):
                 return
             raise
 
+        redact = self.zaptec.redact
+
         self.chargers = []
         for circuit in hierarchy["Circuits"]:
             ctid = circuit["Id"]
-            _LOGGER.debug("    Circuit %s", ctid)
+            redact.add_uid(ctid, "Circuit")
+            _LOGGER.debug("    Circuit %s", redact(ctid))
 
             for charger_item in circuit["Chargers"]:
                 chgid = charger_item["Id"]
+                redact.add_uid(chgid, "Charger")
 
                 # Inject additional attributes
                 charger_item["InstallationId"] = self.id
@@ -286,11 +292,11 @@ class Installation(ZaptecBase):
 
                 # Add or update the charger
                 if chgid in self.zaptec:
-                    _LOGGER.debug("      Charger %s  (existing)", chgid)
+                    _LOGGER.debug("      Charger %s  (existing)", redact(chgid))
                     charger: Charger = self.zaptec[chgid]
                     charger.set_attributes(charger_item)
                 else:
-                    _LOGGER.debug("      Charger %s  (adding)", chgid)
+                    _LOGGER.debug("      Charger %s  (adding)", redact(chgid))
                     charger = Charger(charger_item, self.zaptec, installation=self)
                     self.zaptec.register(chgid, charger)
 
@@ -369,12 +375,10 @@ class Installation(ZaptecBase):
                 data["StateId"] = (
                     f"{data['StateId']} ({ZCONST.observations.get(data['StateId'])})"
                 )
-            if "ChargerId" in data:
-                data["ChargerId"] = self.zaptec.qual_id(data["ChargerId"])
             # Silenty delete these from logging. They are never used
             data.pop("DeviceId", None)
             data.pop("DeviceType", None)
-        _LOGGER.debug("@@@  EVENT %s", data)
+        _LOGGER.debug("@@@  EVENT %s", self.zaptec.redact(data))
 
     async def stream_main(self, cb=None, ssl_context=None):
         """Main stream handler."""
@@ -775,6 +779,7 @@ class Zaptec(Mapping[str, ZaptecBase]):
         client: aiohttp.ClientSession | None = None,
         max_time: float = API_RETRY_MAXTIME,
         show_all_updates: bool = False,
+        redact_logs: bool = True,
     ) -> None:
         """Initialize the Zaptec account handler."""
         self._username = username
@@ -789,6 +794,9 @@ class Zaptec(Mapping[str, ZaptecBase]):
         self._ratelimiter = AsyncLimiter(
             max_rate=API_RATELIMIT_MAX_REQUEST_RATE, time_period=API_RATELIMIT_PERIOD
         )
+
+        self.redact = Redactor(redact_logs)
+        """Redactor for sensitive data in logs."""
 
         self.is_built: bool = False
         """Flag to indicate if the structure of objectes is built and ready to use."""
@@ -938,7 +946,7 @@ class Zaptec(Mapping[str, ZaptecBase]):
                     await asyncio.sleep(sleep_delay)
 
                 # Log the request
-                log_req = list(self._request_log(url, method, iteration, **kwargs))
+                log_req = list(self._request_log(self.redact(url), method, iteration, **kwargs))
                 if DEBUG_API_CALLS:
                     for msg in log_req:
                         _LOGGER.debug(msg)
@@ -1156,20 +1164,28 @@ class Zaptec(Mapping[str, ZaptecBase]):
         const = await self.request("constants")
         ZCONST.clear()
         ZCONST.update(const)
+        ZCONST.update_ids_from_schema(None)
+
+        # Update the redactor
+        self.redact.obs_ids = ZCONST.observations
+        for objid, obj in self._map.items():
+            self.redact.add(objid, replace_by=f"<--{obj.qual_id}-->")
+        redact = self.redact
 
         # Get list of installations
         installations = await self.request("installation")
 
         for inst_item in installations["Data"]:
             instid = inst_item["Id"]
+            self.redact.add_uid(instid, "Inst")
 
             # Add or update the installation object.
             if instid in self:
-                _LOGGER.debug("  Installation %s  (existing)", instid)
+                _LOGGER.debug("  Installation %s  (existing)", redact(instid))
                 installation: Installation = self[instid]
                 installation.set_attributes(inst_item)
             else:
-                _LOGGER.debug("  Installation %s  (adding)", instid)
+                _LOGGER.debug("  Installation %s  (adding)", redact(instid))
                 installation = Installation(inst_item, self)
                 self.register(instid, installation)
 
@@ -1181,7 +1197,7 @@ class Zaptec(Mapping[str, ZaptecBase]):
         if missing_installations := (have_installations - new_installations):
             _LOGGER.warning(
                 "These installations are no longer available but remain in use: %s",
-                missing_installations,
+                redact(missing_installations),
             )
             _LOGGER.warning("To remove them, please restart the integration.")
 
@@ -1190,7 +1206,9 @@ class Zaptec(Mapping[str, ZaptecBase]):
         new_chargers = {d["Id"] for d in chargers["Data"]}
         have_chargers = {c.id for c in self.chargers}
         if missing_chargers := (have_chargers - new_chargers):
-            _LOGGER.warning("These chargers are no longer available: %s", missing_chargers)
+            _LOGGER.warning(
+                "These chargers are no longer available: %s", redact(missing_chargers)
+            )
             _LOGGER.warning("To remove them, please restart the integration.")
 
         # Find the installation based chargers
@@ -1205,15 +1223,16 @@ class Zaptec(Mapping[str, ZaptecBase]):
         # object, so we need to add all the object at this point.
         for charger_item in chargers["Data"]:
             chgid = charger_item["Id"]
+            self.redact.add_uid(chgid, "Charger")
 
             if chgid in installation_chargers:
                 continue  # Skip the chargers which have already been found in installations
             if chgid in self:
-                _LOGGER.debug("  Standalone charger %s  (existing)", chgid)
+                _LOGGER.debug("  Standalone charger %s  (existing)", redact(chgid))
                 charger: Charger = self[chgid]
                 charger.set_attributes(charger_item)
             else:
-                _LOGGER.debug("  Standalone charger %s  (adding)", chgid)
+                _LOGGER.debug("  Standalone charger %s  (adding)", redact(chgid))
                 charger = Charger(charger_item, self, installation=None)
                 self.register(chgid, charger)
 
@@ -1277,6 +1296,10 @@ if __name__ == "__main__":
             await zaptec.login()
             await zaptec.build()
             await zaptec.poll(info=True, state=True, firmware=True)
+
+            # Dump redaction database
+            print("Redaction database:")
+            print(zaptec.redact.dumps())
 
             # Print all the attributes.
             for obj in zaptec.objects():

--- a/custom_components/zaptec/const.py
+++ b/custom_components/zaptec/const.py
@@ -9,6 +9,12 @@ ISSUEURL = "https://github.com/custom-components/zaptec/issues"
 DOMAIN = "zaptec"
 MANUFACTURER = "Zaptec"
 
+REDACT_LOGS = True
+"""Whether to redact sensitive data in logs."""
+
+REDACT_DUMP_ON_STARTUP = True
+"""Whether to dump the redaction database on startup."""
+
 TOKEN_URL = "https://api.zaptec.com/oauth/token"
 API_URL = "https://api.zaptec.com/api/"
 CONST_URL = "https://api.zaptec.com/api/constants"

--- a/custom_components/zaptec/diagnostics.py
+++ b/custom_components/zaptec/diagnostics.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import logging
-from pprint import pformat
 import traceback
-from typing import Any, ClassVar, TypeVar, cast
+from typing import Any
 
 # to Support running this as a script.
 if __name__ != "__main__":
@@ -14,11 +13,9 @@ if __name__ != "__main__":
 
 from . import ZaptecConfigEntry, ZaptecManager
 from .api import ZCONST, Zaptec, ZaptecBase
+from .redact import Redactor
 
 _LOGGER = logging.getLogger(__name__)
-
-
-T = TypeVar("T")
 
 # If this is true, the output data will be redacted.
 DO_REDACT = True
@@ -27,165 +24,6 @@ DO_REDACT = True
 # If this is set to True, the redacted data will be included in the output.
 # USE WITH CAUTION! This will include sensitive data in the output.
 INCLUDE_REDACTS = False
-
-
-class Redactor:
-    """Class to handle redaction of sensitive data."""
-
-    # Data fields that must be redacted from the output
-    REDACT_KEYS: ClassVar[list[str]] = [
-        "Address",
-        "ChargerId",
-        "ChargerCurrentUserUuid",
-        "CircuitId",
-        "City",
-        "DeviceId",
-        "Id",
-        "ID",
-        "InstallationId",
-        "InstallationName",
-        "Latitude",
-        "LogoBase64",
-        "Longitude",
-        "LteIccid",
-        "LteImei",
-        "LteImsi",
-        "MacWiFi",
-        "MacMain",
-        "MacPlcModuleGrid",
-        "MID",
-        "Name",
-        "NewChargeCard",
-        "PilotTestResults",
-        "Pin",
-        "ProductionTestResults",
-        "SerialNo",
-        "SupportGroup",
-        "ZipCode",
-    ]
-
-    # Never redact these words
-    NEVER_REDACT: ClassVar[list] = [
-        None,
-        True,
-        False,
-        "true",
-        "false",
-        "0",
-        "0.",
-        "0.0",
-        0,
-        0.0,
-        "1",
-        "1.",
-        "1.0",
-        1,
-        1.0,
-        "",
-    ]
-
-    # Keys that will be looked up into the observer id dict
-    OBS_KEYS: ClassVar[list[str]] = ["SettingId", "StateId"]
-
-    # Key names that will be redacted if they the dict has a OBS_KEY entry
-    # and it is in the REDACT_KEYS list.
-    VALUES: ClassVar[list[str]] = [
-        "Value",
-        "ValueAsString",
-    ]
-
-    def __init__(self, do_redact: bool, obs_ids: dict[str, str] | None = None):
-        self.do_redact = do_redact
-        self.obs_ids = obs_ids or {}
-        self.redacts = {}
-        self.redact_info = {}
-
-    def dumps(self) -> str:
-        """Dump the redaction database in a readable format."""
-        return pformat(
-            {k: v["text"] for k, v in self.redact_info.items()},
-        )
-
-    def add(self, obj, *, key=None, replace_by=None, ctx=None) -> str:
-        """Add a new redaction to the list."""
-        if not replace_by:
-            replace_by = f"<--Redact #{len(self.redacts) + 1}-->"
-        self.redacts[obj] = replace_by
-        self.redact_info[replace_by] = {  # For statistics only
-            "text": obj,
-            "from": f"{key} in {ctx}" if key else ctx,
-        }
-        return replace_by
-
-    def add_uid(self, uid, name, *, ctx=None) -> str:
-        """Add a new redaction for a UID."""
-        return self.add(uid, replace_by=f"<--{name}[{uid[-6:]}]-->", ctx=ctx)
-
-    def __call__(self, obj: T, *, key=None, second_pass=False, ctx=None) -> T:
-        """Redact the object if it is present in the redacted dict.
-
-        A new redaction is created if make_new is not None. ctx is
-        for logging output.
-        """
-
-        if not self.do_redact:
-            return obj
-
-        if isinstance(obj, (tuple, list)):
-            # Redact each element in the list
-            return cast(
-                T,
-                [self(k, key=key, second_pass=second_pass, ctx=ctx) for k in obj],
-            )
-
-        if isinstance(obj, dict):
-            # Redact each value in the dict. Unless secondpass is set, the keys
-            # are checked if they are in the REDACT_KEYS list.
-            return cast(
-                T,
-                {
-                    k: self(
-                        v,
-                        key=k if not second_pass else key,
-                        second_pass=second_pass,
-                        ctx=ctx,
-                    )
-                    for k, v in obj.items()
-                },
-            )
-
-        # Check if the object is already redacted
-        if obj in self.redacts:
-            return self.redacts[obj]
-
-        # Check if new redaction is needed
-        if key and key in self.REDACT_KEYS and (not obj or obj not in self.NEVER_REDACT):
-            return cast(T, self.add(obj, key=key, ctx=ctx))
-
-        # Check if the string contains a redacted string
-        if isinstance(obj, str):
-            for k, v in self.redacts.items():
-                if isinstance(k, str) and k in obj:
-                    obj = obj.replace(k, v)
-
-        return obj
-
-    def redact_statelist(self, objs, ctx=None):
-        """Redact the special state list objects."""
-        for obj in objs:
-            for key in self.OBS_KEYS:
-                if key not in obj:
-                    continue
-                keyv = self.obs_ids.get(obj[key])
-                if keyv is not None:
-                    obj[key] = f"{obj[key]} ({keyv})"
-                if keyv not in self.REDACT_KEYS:
-                    continue
-                for value in self.VALUES:
-                    if value not in obj:
-                        continue
-                    obj[value] = self(obj[value], key=obj[key], ctx=ctx)
-        return objs
 
 
 async def async_get_config_entry_diagnostics(

--- a/custom_components/zaptec/redact.py
+++ b/custom_components/zaptec/redact.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pprint import pformat
 from typing import ClassVar, TypeVar, cast
 
 T = TypeVar("T")

--- a/custom_components/zaptec/redact.py
+++ b/custom_components/zaptec/redact.py
@@ -1,0 +1,166 @@
+"""Helper class to redact sensitive data from the API logging."""
+
+from __future__ import annotations
+
+from typing import ClassVar, TypeVar, cast
+
+T = TypeVar("T")
+
+
+class Redactor:
+    """Class to handle redaction of sensitive data."""
+
+    # Data fields that must be redacted from the output
+    REDACT_KEYS: ClassVar[list[str]] = [
+        "Address",
+        "ChargerId",
+        "ChargerCurrentUserUuid",
+        "CircuitId",
+        "City",
+        "DeviceId",
+        "Id",
+        "ID",
+        "InstallationId",
+        "InstallationName",
+        "Latitude",
+        "LogoBase64",
+        "Longitude",
+        "LteIccid",
+        "LteImei",
+        "LteImsi",
+        "MacWiFi",
+        "MacMain",
+        "MacPlcModuleGrid",
+        "MID",
+        "Name",
+        "NewChargeCard",
+        "PilotTestResults",
+        "Pin",
+        "ProductionTestResults",
+        "SerialNo",
+        "SupportGroup",
+        "ZipCode",
+    ]
+
+    # Never redact these words
+    NEVER_REDACT: ClassVar[list] = [
+        None,
+        True,
+        False,
+        "true",
+        "false",
+        "0",
+        "0.",
+        "0.0",
+        0,
+        0.0,
+        "1",
+        "1.",
+        "1.0",
+        1,
+        1.0,
+        "",
+    ]
+
+    # Keys that will be looked up into the observer id dict
+    OBS_KEYS: ClassVar[list[str]] = ["SettingId", "StateId"]
+
+    # Key names that will be redacted if they the dict has a OBS_KEY entry
+    # and it is in the REDACT_KEYS list.
+    VALUES: ClassVar[list[str]] = [
+        "Value",
+        "ValueAsString",
+    ]
+
+    def __init__(self, do_redact: bool, obs_ids: dict[str, str] | None = None):
+        self.do_redact = do_redact
+        self.obs_ids = obs_ids or {}
+        self.redacts = {}
+        self.redact_info = {}
+
+    def dumps(self) -> str:
+        """Dump the redaction database in a readable format."""
+        return pformat(
+            {k: v["text"] for k, v in self.redact_info.items()},
+        )
+
+    def add(self, obj, *, key=None, replace_by=None, ctx=None) -> str:
+        """Add a new redaction to the list."""
+        if not replace_by:
+            replace_by = f"<--Redact #{len(self.redacts) + 1}-->"
+        self.redacts[obj] = replace_by
+        self.redact_info[replace_by] = {  # For statistics only
+            "text": obj,
+            "from": f"{key} in {ctx}" if key else ctx,
+        }
+        return replace_by
+
+    def add_uid(self, uid, name, *, ctx=None) -> str:
+        """Add a new redaction for a UID."""
+        return self.add(uid, replace_by=f"<--{name}[{uid[-6:]}]-->", ctx=ctx)
+
+    def __call__(self, obj: T, *, key=None, second_pass=False, ctx=None) -> T:
+        """Redact the object if it is present in the redacted dict.
+
+        A new redaction is created if make_new is not None. ctx is
+        for logging output.
+        """
+
+        if not self.do_redact:
+            return obj
+
+        if isinstance(obj, (tuple, list)):
+            # Redact each element in the list
+            return cast(
+                T,
+                [self(k, key=key, second_pass=second_pass, ctx=ctx) for k in obj],
+            )
+
+        if isinstance(obj, dict):
+            # Redact each value in the dict. Unless secondpass is set, the keys
+            # are checked if they are in the REDACT_KEYS list.
+            return cast(
+                T,
+                {
+                    k: self(
+                        v,
+                        key=k if not second_pass else key,
+                        second_pass=second_pass,
+                        ctx=ctx,
+                    )
+                    for k, v in obj.items()
+                },
+            )
+
+        # Check if the object is already redacted
+        if obj in self.redacts:
+            return self.redacts[obj]
+
+        # Check if new redaction is needed
+        if key and key in self.REDACT_KEYS and (not obj or obj not in self.NEVER_REDACT):
+            return cast(T, self.add(obj, key=key, ctx=ctx))
+
+        # Check if the string contains a redacted string
+        if isinstance(obj, str):
+            for k, v in self.redacts.items():
+                if isinstance(k, str) and k in obj:
+                    obj = obj.replace(k, v)
+
+        return obj
+
+    def redact_statelist(self, objs, ctx=None):
+        """Redact the special state list objects."""
+        for obj in objs:
+            for key in self.OBS_KEYS:
+                if key not in obj:
+                    continue
+                keyv = self.obs_ids.get(obj[key])
+                if keyv is not None:
+                    obj[key] = f"{obj[key]} ({keyv})"
+                if keyv not in self.REDACT_KEYS:
+                    continue
+                for value in self.VALUES:
+                    if value not in obj:
+                        continue
+                    obj[value] = self(obj[value], key=obj[key], ctx=ctx)
+        return objs


### PR DESCRIPTION
This is a proposal to fix #255. The PR adds a system for redaction of sensitive data. This is the same system previously used for the diagnostics download, which is now repurposed for all logging from api.py. The overall idea is that it should be safe to share the debug logs -- with the exception of the redaction database which is clearly marked in the log.

A log entry typically looks like this with all sensitive data redacted:

```
@@@  REQUEST GET to 'https://api.zaptec.com/api/installation'
@@@  RESPONSE 200 length 1118
   Installation <--Inst[8a106b]-->  (adding)
>>>  Adding   Installation.id (Id)  =  <str> '<--Inst[8a106b]-->'
>>>  Adding   Installation[8a106b].name (Name)  =  <str> '<--Redact #2-->'
>>>  Adding   Installation[8a106b].address (Address)  =  <str> '<--Redact #3-->'
```

The redacted stings are found in `"<--Text-->"` brackets. At the end of setup if `REDACT_DUMP_ON_STARTUP` is set, will print the following in the logs.

```
------  DO NOT PUBLISH THE FOLLOWING DATA  ------
|  Redaction database:
|  {'<--Inst[8a106b]-->': '...the actual value....',
|   '<--Redact #2-->': '...the actual value....',
|   '<--Redact #3-->': '...the actual value....'}
------  DO NOT PUBLISH THE ABOVE ^^^ DATA  ------
```

The setting `REDACT_LOGS = False` (in const.py) can be used to disable redaction completely. I've chosen to set `REDACT_DUMP_ON_STARTUP = True` so there is a chance to extract the actual values from the logs if need be. But users must make sure they don't share that part of the logs.

The downside to this solution, is that it adds even more complexity to the library and that we can never guarantee 100% that any sensitive information will not fall through the filter.

Is this PR a good idea, or just added complexity?