### PR TITLE
Fix startup of deselected chargers

### DIFF
--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -399,6 +399,10 @@ class ZaptecManager:
 
         entities: list[ZaptecBaseEntity] = []
         for description in descriptions:
+            # Make sure this zaptec object is tracked
+            if zaptec_obj.id not in self.tracked_devices:
+                continue
+
             # Use provided class if it exists, otherwise use the class this
             # function was called from
             cls: type[ZaptecBaseEntity] = description.cls


### PR DESCRIPTION
This PR ensures that entities are only created if the zaptec object is tracked. Without it it cause a failure during startup if a subset of chargers have been selected.

Fix #274 