### PR TITLE
Update translations for reconfigure

### DIFF
--- a/custom_components/zaptec/translations/en.json
+++ b/custom_components/zaptec/translations/en.json
@@ -17,6 +17,16 @@
                     "chargers": "Chargers"
                 }
             },
+            "reconfigure": {
+                "title": "Reconfigure Zaptec",
+                "description": "Zaptec Portal login details.\n\nThe optional prefix will add the prefix to all devices. Note that it is generally better to rename the device names in HA than adding a prefix.",
+                "data": {
+                    "manual_select": "Manually select chargers. Next screen will select the chargers to add.",
+                    "password": "Password",
+                    "prefix": "Optional prefix",
+                    "username": "Username"
+                }
+            },
             "user": {
                 "title": "Zaptec setup",
                 "description": "Add your Zaptec Portal login details.\n\nThe optional prefix will add the prefix to all devices. Note that it is generally better to rename the device names in HA than adding a prefix.",
@@ -24,7 +34,6 @@
                     "manual_select": "Manually select chargers. Next screen will select the chargers to add.",
                     "password": "Password",
                     "prefix": "Optional prefix",
-                    "scan_interval": "Scan interval",
                     "username": "Username"
                 }
             }

--- a/custom_components/zaptec/translations/nl.json
+++ b/custom_components/zaptec/translations/nl.json
@@ -17,6 +17,16 @@
                     "chargers": "Opladers"
                 }
             },
+            "reconfigure": {
+                "title": "Zaptec opnieuw configureren",
+                "description": "Inloggegevens voor Zaptec Portal.\n\nMet het optionele voorvoegsel wordt het voorvoegsel aan alle apparaten toegevoegd. Merk op dat het doorgaans beter is om de apparaatnamen in HA te hernoemen dan een voorvoegsel toe te voegen.",
+                "data": {
+                    "manual_select": "Handmatig opladers selecteren. Op het volgende scherm worden de opladers weergegeven die toegevoegd kunnen worden.",
+                    "password": "Wachtwoord",
+                    "prefix": "Optioneel voorvoegsel",
+                    "username": "Gebruikersnaam"
+                }
+            },
             "user": {
                 "title": "Zaptec setup",
                 "description": "Voeg uw Zaptec Portal inloggegevens toe.\n\nMet het optionele voorvoegsel wordt het voorvoegsel aan alle apparaten toegevoegd. Merk op dat het doorgaans beter is om de apparaatnamen in HA te hernoemen dan een voorvoegsel toe te voegen.",
@@ -24,7 +34,6 @@
                     "manual_select": "Handmatig opladers selecteren. Op het volgende scherm worden de opladers weergegeven die toegevoegd kunnen worden.",
                     "password": "Wachtwoord",
                     "prefix": "Optioneel voorvoegsel",
-                    "scan_interval": "Scaninterval",
                     "username": "Gebruikersnaam"
                 }
             }

--- a/custom_components/zaptec/translations/pl.json
+++ b/custom_components/zaptec/translations/pl.json
@@ -17,6 +17,16 @@
                     "chargers": "Ładowarki"
                 }
             },
+            "reconfigure": {
+                "title": "Ponowna konfiguracja Zaptec",
+                "description": "Dane logowania do Zaptec Portal.\n\nOpcjonalny prefiks doda prefiks do wszystkich urządzeń. Należy pamiętać, że lepiej jest zmienić nazwy urządzeń w HA niż dodawać prefiks.",
+                "data": {
+                    "manual_select": "Ręczne wybieranie ładowarek. Na następnym ekranie wybierz ładowarki do dodania.",
+                    "password": "Hasło",
+                    "prefix": "Opcjonalny prefiks",
+                    "username": "Nazwa użytkownika"
+                }
+            },
             "user": {
                 "title": "Konfiguracja Zaptec",
                 "description": "Dodaj swoje dane logowania do Zaptec Portal.\n\nOpcjonalny prefiks doda prefiks do wszystkich urządzeń. Należy pamiętać, że lepiej jest zmienić nazwy urządzeń w HA niż dodawać prefiks.",
@@ -24,7 +34,6 @@
                     "manual_select": "Ręczne wybieranie ładowarek. Na następnym ekranie wybierz ładowarki do dodania.",
                     "password": "Hasło",
                     "prefix": "Opcjonalny prefiks",
-                    "scan_interval": "Interwał skanowania",
                     "username": "Nazwa użytkownika"
                 }
             }

--- a/custom_components/zaptec/translations/sv.json
+++ b/custom_components/zaptec/translations/sv.json
@@ -17,6 +17,16 @@
                     "chargers": "Laddare"
                 }
             },
+            "reconfigure": {
+                "title": "Konfigurera om Zaptec",
+                "description": "Inloggningsuppgifter för Zaptec-portalen.\n\nDet valfria prefixet kommer att bli tillagt på alla enheter. Notera att det oftast är bättre att ändra namn på enheterna i HA än att lägga till prefix.",
+                "data": {
+                    "manual_select": "Välj laddare manuellt. Nästa ruta visar vilka laddare att lägga till.",
+                    "password": "Lösenord",
+                    "prefix": "Valfritt prefix",
+                    "username": "Användarnamn"
+                }
+            },
             "user": {
                 "title": "Zaptec setup",
                 "description": "Lägg till dina Zaptec Portal login detaljer.\n\nDet valfria prefixet kommer att bli tillagt på alla enheter. Notera att det oftast är bättre att ändra namn på enheterna i HA än att lägga till prefix.",
@@ -24,7 +34,6 @@
                     "manual_select": "Välj laddare manuellt. Nästa ruta visar vilka laddare att lägga till.",
                     "password": "Lösenord",
                     "prefix": "Valfritt prefix",
-                    "scan_interval": "Uppdaterings intervall",
                     "username": "Användarnamn"
                 }
             }


### PR DESCRIPTION
Add missing translations for Zaptec reconfiguration.

Fix #273 