### PR TITLE
Reclassify entities from diagnostic to config where appropriate

### DIFF
--- a/custom_components/zaptec/button.py
+++ b/custom_components/zaptec/button.py
@@ -81,14 +81,14 @@ CHARGER_ENTITIES: list[EntityDescription] = [
     ZapButtonEntityDescription(
         key="restart_charger",
         translation_key="restart_charger",
-        entity_category=const.EntityCategory.DIAGNOSTIC,
+        entity_category=const.EntityCategory.CONFIG,
         icon="mdi:restart",
         cls=ZaptecButton,
     ),
     ZapButtonEntityDescription(
         key="upgrade_firmware",
         translation_key="upgrade_firmware",
-        entity_category=const.EntityCategory.DIAGNOSTIC,
+        entity_category=const.EntityCategory.CONFIG,
         icon="mdi:memory",
         cls=ZaptecButton,
     ),

--- a/custom_components/zaptec/number.py
+++ b/custom_components/zaptec/number.py
@@ -201,7 +201,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
     ZapNumberEntityDescription(
         key="hmi_brightness",
         translation_key="hmi_brightness",
-        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_category=EntityCategory.CONFIG,
         icon="mdi:brightness-6",
         native_unit_of_measurement=const.PERCENTAGE,
         cls=ZaptecHmiBrightness,

--- a/custom_components/zaptec/switch.py
+++ b/custom_components/zaptec/switch.py
@@ -142,7 +142,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
     ZapSwitchEntityDescription(
         key="permanent_cable_lock",
         translation_key="permanent_cable_lock",
-        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_category=EntityCategory.CONFIG,
         cls=ZaptecCableLockSwitch,
     ),
 ]

--- a/custom_components/zaptec/update.py
+++ b/custom_components/zaptec/update.py
@@ -69,8 +69,7 @@ CHARGER_ENTITIES: list[EntityDescription] = [
         key="firmware_update",
         translation_key="firmware_update",
         device_class=UpdateDeviceClass.FIRMWARE,
-        entity_category=const.EntityCategory.DIAGNOSTIC,
-        # icon="mdi:lock",  # FIXME: Find how icons work for firmware
+        entity_category=const.EntityCategory.CONFIG,
         cls=ZaptecUpdate,
     ),
 ]


### PR DESCRIPTION
According to [integration-quality-scale/rules/entity-category](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/entity-category/) and the associated [documentation](https://developers.home-assistant.io/docs/core/entity#registry-properties)
Fixes #279 