### PR TITLE
Run ruff ci but ignore errors

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -26,3 +26,22 @@ jobs:
         uses: hacs/action@main
         with:
           category: integration
+
+  lint-ruff:
+    name: Ruff validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Run ruff format
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: format --diff
+          src: "."
+
+      - name: Run ruff check
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: check --exit-zero # succeed despite errors until https://github.com/custom-components/zaptec/issues/258 is done
+          src: "."

--- a/custom_components/zaptec/services.py
+++ b/custom_components/zaptec/services.py
@@ -283,11 +283,17 @@ async def async_setup_services(hass: HomeAssistant, manager: ZaptecManager) -> N
         # only add the relevant arguments if they are not None
         if (available_current := service_call.data.get("available_current")) is not None:
             limit_args["availableCurrent"] = available_current
-        if (available_current_phase1 := service_call.data.get("available_current_phase1")) is not None:
+        if (
+            available_current_phase1 := service_call.data.get("available_current_phase1")
+        ) is not None:
             limit_args["availableCurrentPhase1"] = available_current_phase1
-        if (available_current_phase2 := service_call.data.get("available_current_phase2")) is not None:
+        if (
+            available_current_phase2 := service_call.data.get("available_current_phase2")
+        ) is not None:
             limit_args["availableCurrentPhase2"] = available_current_phase2
-        if (available_current_phase3 := service_call.data.get("available_current_phase3")) is not None:
+        if (
+            available_current_phase3 := service_call.data.get("available_current_phase3")
+        ) is not None:
             limit_args["availableCurrentPhase3"] = available_current_phase3
         for coordinator, obj in iter_objects(service_call, mustbe=Installation):
             _LOGGER.debug("  >> to %s", obj.id)

--- a/scripts/lint
+++ b/scripts/lint
@@ -4,5 +4,13 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-ruff format .
-ruff check . --fix
+if [ "$1" = "ci" ]; then
+    # Don't try to fix errors, just fail
+    ruff format . --diff
+    ruff check . --exit-zero # succeed despite errors until https://github.com/custom-components/zaptec/issues/258 is done
+    # ruff check .
+else
+    # Auto-fix as much as possible
+    ruff format .
+    ruff check . --fix
+fi


### PR DESCRIPTION
Adds ruff validation to make sure we don't regress on formatting and showing our progress towards #258 

Thanks to `--exit-zero` the tests still passes despite us still having 296 errors.