### PR TITLE
Disable ruff errors that HA core is also ignoring

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -28,6 +28,10 @@ ignore = [
 
     "TRY003", # Avoid specifying long messages outside the exception class
     "TRY400", # Use `logging.exception` instead of `logging.error`
+
+    # definitely skipped in HA, not obvious how
+    "EM101",  # Exception must not use a string literal, assign to variable first
+    "EM102",  # Exception must not use an f-string literal, assign to variable first
 ]
 
 [lint.flake8-pytest-style]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -32,6 +32,8 @@ ignore = [
     # definitely skipped in HA, not obvious how
     "EM101",  # Exception must not use a string literal, assign to variable first
     "EM102",  # Exception must not use an f-string literal, assign to variable first
+    "FBT001", # Boolean-typed positional argument in function definition
+    "FBT002", # Boolean default positional argument in function definition
 ]
 
 [lint.flake8-pytest-style]


### PR DESCRIPTION
Simple example from HA core that violates both of the boolean rules: https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/entity_platform.py#L79