### PR TITLE
Move ZCONST into const to make it importable

### DIFF
--- a/custom_components/zaptec/diagnostics.py
+++ b/custom_components/zaptec/diagnostics.py
@@ -56,7 +56,7 @@ async def _get_diagnostics(
     zaptec: Zaptec = manager.zaptec
 
     # Helper to redact the output data
-    redact = Redactor(DO_REDACT, ZCONST.observations)
+    redact = Redactor(DO_REDACT)
 
     def add_failure(err: Exception) -> None:
         """Add a failure to the output."""

--- a/custom_components/zaptec/zaptec/__init__.py
+++ b/custom_components/zaptec/zaptec/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from .api import ZCONST, Charger, Installation, Zaptec, ZaptecBase
-from .const import MISSING, Missing
+from .api import Charger, Installation, Zaptec, ZaptecBase
+from .const import MISSING, ZCONST, Missing
 from .exceptions import (
     AuthenticationError,
     RequestConnectionError,

--- a/custom_components/zaptec/zaptec/api.py
+++ b/custom_components/zaptec/zaptec/api.py
@@ -33,6 +33,7 @@ from .const import (
     MISSING,
     TOKEN_URL,
     TRUTHY,
+    ZCONST,
 )
 from .exceptions import (
     AuthenticationError,
@@ -45,7 +46,7 @@ from .exceptions import (
 from .misc import mc_nbfx_decoder, to_under
 from .redact import Redactor
 from .validate import validate
-from .zconst import CommandType, ZConst
+from .zconst import CommandType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,9 +54,6 @@ _LOGGER = logging.getLogger(__name__)
 DEBUG_API_CALLS = True
 DEBUG_API_DATA = False
 DEBUG_API_EXCEPTIONS = False
-
-# Global var for the API constants from Zaptec
-ZCONST: ZConst = ZConst()
 
 # Type definitions
 TValue = str | int | float | bool
@@ -1174,7 +1172,6 @@ class Zaptec(Mapping[str, ZaptecBase]):
         ZCONST.update_ids_from_schema(None)
 
         # Update the redactor
-        self.redact.obs_ids = ZCONST.observations
         for objid, obj in self._map.items():
             self.redact.add(objid, replace_by=f"<--{obj.qual_id}-->")
         redact = self.redact

--- a/custom_components/zaptec/zaptec/const.py
+++ b/custom_components/zaptec/zaptec/const.py
@@ -2,14 +2,7 @@
 
 from __future__ import annotations
 
-
-class Missing:
-    """Singleton class representing a missing value."""
-
-
-MISSING = Missing()
-"""Singleton instance representing a missing value."""
-
+from .zconst import ZConst
 
 TOKEN_URL = "https://api.zaptec.com/oauth/token"  # noqa: S105
 API_URL = "https://api.zaptec.com/api/"
@@ -49,3 +42,15 @@ CHARGER_EXCLUDES = {
     "900",  # ProductionTestResults
     "980",  # MIDCalibration
 }
+
+
+class Missing:
+    """Singleton class representing a missing value."""
+
+
+MISSING = Missing()
+"""Singleton instance representing a missing value."""
+
+
+ZCONST = ZConst()
+"""Zaptec constants wrapper instance."""

--- a/custom_components/zaptec/zaptec/redact.py
+++ b/custom_components/zaptec/zaptec/redact.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pprint import pformat
 from typing import ClassVar, TypeVar, cast
 
+from .const import ZCONST
+
 T = TypeVar("T")
 
 
@@ -73,10 +75,9 @@ class Redactor:
         "ValueAsString",
     ]
 
-    def __init__(self, do_redact: bool, obs_ids: dict[str, str] | None = None) -> None:
+    def __init__(self, do_redact: bool) -> None:
         """Initialize redactor."""
         self.do_redact = do_redact
-        self.obs_ids = obs_ids or {}
         self.redacts = {}
         self.redact_info = {}
 
@@ -156,7 +157,7 @@ class Redactor:
             for key in self.OBS_KEYS:
                 if key not in obj:
                     continue
-                keyv = self.obs_ids.get(obj[key])
+                keyv = ZCONST.observations.get(obj[key])
                 if keyv is not None:
                     obj[key] = f"{obj[key]} ({keyv})"
                 if keyv not in self.REDACT_KEYS:


### PR DESCRIPTION
* Move ZCONST initialization from api to const
* Use ZCONST in Redactor instead of class argument

By moving ZCONST initialization from api.py to const.py, it will be easier to use ZCONST from anywhere in the code. One example is what's included in the PR: The redact.py can now use ZCONST directly and doesn't need to get the data passed on via the class instance initialization.
