### PR TITLE
Cleanup misc - add typing and tests

### DIFF
--- a/custom_components/zaptec/zaptec/misc.py
+++ b/custom_components/zaptec/zaptec/misc.py
@@ -24,15 +24,15 @@ def to_under(word: str) -> str:
 def data_producer(data: bytes) -> Generator[bytes, int, None]:  # noqa: UP043
     """Generate data segments from input bytes.
 
-    Use send(count) to get the next block of 'size' bytes.
+    Use successive send(size) to get the next block of 'size' bytes.
     """
     size = 0
-    first = True  # Make sure the first next() goes through with empty data
+    first = True  # Make sure the first next() goes through even with empty data
     while first or data:
         first = False
         block = data[:size]
         data = data[size:]
-        # Send the block of data of count size
+        # Send the block of data of size bytes
         size = yield block
 
 

--- a/custom_components/zaptec/zaptec/misc.py
+++ b/custom_components/zaptec/zaptec/misc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 import re
 
 # Precompile the patterns for performance
@@ -10,7 +11,7 @@ RE_TO_UNDER2 = re.compile(r"([a-z\d])([A-Z])")
 
 
 def to_under(word: str) -> str:
-    """Helper to convert TurnOnThisButton to turn_on_this_button."""
+    """Convert TurnOnThisButton to turn_on_this_button."""
     # Ripped from inflection
     word = RE_TO_UNDER1.sub(r"\1_\2", word)
     word = RE_TO_UNDER2.sub(r"\1_\2", word)
@@ -18,38 +19,49 @@ def to_under(word: str) -> str:
     return word.lower()
 
 
-def mc_nbfx_decoder(msg: bytes) -> None:
-    """Decoder of .NET Binary Format XML Data structures."""
+# This Generator[] cannot be shortened to the new 3.13 style, since it use
+# values from send(). Ignoring UP043
+def data_producer(data: bytes) -> Generator[bytes, int, None]:  # noqa: UP043
+    """Generate data segments from input bytes.
+
+    Use send(count) to get the next block of 'size' bytes.
+    """
+    size = 0
+    first = True  # Make sure the first next() goes through with empty data
+    while first or data:
+        first = False
+        block = data[:size]
+        data = data[size:]
+        # Send the block of data of count size
+        size = yield block
+
+
+# NBFX Record Types
+END_ELEMENT = 0x01
+SHORT_XMLNS_ATTRIBUTE = 0x08
+SHORT_ELEMENT = 0x40
+CHARS8TEXT = 0x98
+CHARS16TEXT = 0x9A
+
+
+def mc_nbfx_decoder(msg: bytes) -> list[dict[str, str]]:
+    """Decode .NET Binary Format XML Data structures."""
 
     # https://learn.microsoft.com/en-us/openspecs/windows_protocols/mc-nbfx
-
-    def data_producer(data: bytes):
-        """Generator of data."""
-        count = 0
-        while data:
-            block = data[:count]
-            data = data[count:]
-            count = yield block
 
     prod = data_producer(msg)
     next(prod)
 
-    END_ELEMENT = 0x01
-    SHORT_XMLNS_ATTRIBUTE = 0x08
-    SHORT_ELEMENT = 0x40
-    CHARS8TEXT = 0x98
-    CHARS16TEXT = 0x9A
-
-    def read_string(bits16=False):
+    def read_string(record_type: int) -> str:
         """Read a string."""
-        if bits16:
+        if record_type == CHARS16TEXT:
             b = prod.send(2)
             length = b[0] + (b[1] << 8)
         else:
             length = prod.send(1)[0]
         return prod.send(length).decode("utf-8")
 
-    def frame_decoder():
+    def frame_decoder() -> Generator[tuple[int, str | None]]:
         """Decode the stream."""
         while True:
             try:
@@ -63,7 +75,7 @@ def mc_nbfx_decoder(msg: bytes) -> None:
                 CHARS8TEXT,
                 CHARS16TEXT,
             ):
-                yield record_type, read_string(bits16=(record_type == CHARS16TEXT))
+                yield record_type, read_string(record_type)
             elif record_type == END_ELEMENT:
                 yield record_type, None
             else:
@@ -101,14 +113,7 @@ def get_ocmf_max_reader_value(data: dict) -> float:
 
     if not isinstance(data, dict):
         return 0.0
-    return max(float(reading.get("RV", 0.0)) for reading in data.get("RD", []))
-
-
-if __name__ == "__main__":
-    from pprint import pprint
-
-    data = b'@\x06string\x083http://schemas.microsoft.com/2003/10/Serialization/\x98\xa5{"DeviceId":"ZAP000000","DeviceType":4,"ChargerId":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","StateId":523,"Timestamp":"2023-07-28T09:07:19.23","ValueAsString":"0.000"}\x01'
-    data = b'@\x06string\x083http://schemas.microsoft.com/2003/10/Serialization/\x9a\x87\x01{"DeviceId":"ZAP000000","DeviceType":4,"ChargerId":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","StateId":554,"Timestamp":"2023-08-03T00:00:00.0617Z","ValueAsString":"OCMF|{\\"FV\\":\\"1.0\\",\\"GI\\":\\"ZAPTEC GO\\",\\"GS\\":\\"ZAP000000\\",\\"GV\\":\\"2.1.0.4\\",\\"PG\\":\\"F1\\",\\"RD\\":[{\\"TM\\":\\"2023-08-03T00:00:00,000+00:00 R\\",\\"RV\\":179.715,\\"RI\\":\\"1-0:1.8.0\\",\\"RU\\":\\"kWh\\",\\"RT\\":\\"AC\\",\\"ST\\":\\"G\\"}]}"}\x01'
-
-    out = mc_nbfx_decoder(data)
-    pprint(out)
+    rds = data.get("RD", [])
+    if not rds:
+        return 0.0
+    return max(float(reading.get("RV", 0.0)) for reading in rds)

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,5 +1,0 @@
-from custom_components.zaptec.zaptec import Zaptec
-
-
-async def test_placeholder():
-    assert True

--- a/tests/zaptec/test_misc.py
+++ b/tests/zaptec/test_misc.py
@@ -1,0 +1,143 @@
+"""Tests for zaptec.misc.py."""
+
+import pytest
+
+from custom_components.zaptec.zaptec.misc import (
+    data_producer,
+    get_ocmf_max_reader_value,
+    mc_nbfx_decoder,
+    to_under,
+)
+
+
+def test_misc_data_producer() -> None:
+    """Test the data_producer function."""
+    data = b"Hello, World!"
+    producer = data_producer(data)
+    next(producer)  # Prime the generator
+
+    assert producer.send(5) == b"Hello"
+    assert producer.send(2) == b", "
+    assert producer.send(6) == b"World!"
+    with pytest.raises(StopIteration):
+        producer.send(1)  # Data is exhausted
+
+    # Test with empty data
+    data = b""
+    producer = data_producer(data)
+    next(producer)  # Prime the generator
+    with pytest.raises(StopIteration):
+        producer.send(5)  # Data is exhausted
+
+
+def test_misc_get_ocmf_max_reader_value() -> None:
+    """Test the get_ocmf_max_reader_value function."""
+    data = {
+        "RD": [
+            {"RV": 100.0},
+            {"RV": 150.5},
+            {"RV": 120.3},
+        ]
+    }
+    assert get_ocmf_max_reader_value(data) == 150.5  # noqa: PLR2004
+
+    data_none = None
+    assert get_ocmf_max_reader_value(data_none) == 0.0
+
+    data_empty = {"RD": []}
+    assert get_ocmf_max_reader_value(data_empty) == 0.0
+
+    data_no_rd = {}
+    assert get_ocmf_max_reader_value(data_no_rd) == 0.0
+
+    data_missing_rv = {"RD": [{"RI": "1-0:1.8.0"}]}
+    assert get_ocmf_max_reader_value(data_missing_rv) == 0.0
+
+
+def test_misc_mc_nbfx_decoder() -> None:
+    """Test the mc_nbfx_decoder function."""
+    # Example NBFX encoded message (hex)
+    nbfx_message = bytes.fromhex(
+        "40 05 48 65 6c 6c 6f"  # SHORT_ELEMENT "Hello"
+        "08 03 78 6d 6c"  # SHORT_XMLNS_ATTRIBUTE "xml"
+        "98 05 57 6f 72 6c 64"  # CHARS8TEXT "World"
+        "01"  # END_ELEMENT
+    )
+
+    expected_output = [{"name": "Hello", "xmlns": "xml", "text": "World"}]
+
+    result = mc_nbfx_decoder(nbfx_message)
+    assert result == expected_output
+
+
+def test_misc_mc_nbfx_decoder_example1() -> None:
+    """Test the mc_nbfx_decoder function with a real-world example."""
+    nbfx_message = (
+        b"@\x06string\x083http://schemas.microsoft.com/2003/10/Serialization/"
+        b'\x98\xa5{"DeviceId":"ZAP000000","DeviceType":4,'
+        b'"ChargerId":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","StateId":523,'
+        b'"Timestamp":"2023-07-28T09:07:19.23","ValueAsString":"0.000"}\x01'
+    )
+
+    expected_output = [
+        {
+            "name": "string",
+            "text": (
+                '{"DeviceId":"ZAP000000","DeviceType":4,'
+                '"ChargerId":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","StateId":523,'
+                '"Timestamp":"2023-07-28T09:07:19.23","ValueAsString":"0.000"}'
+            ),
+            "xmlns": "http://schemas.microsoft.com/2003/10/Serialization/",
+        }
+    ]
+
+    result = mc_nbfx_decoder(nbfx_message)
+    assert result == expected_output, f"Expected {expected_output}, got {result}"
+
+
+def test_misc_mc_nbfx_decoder_example2() -> None:
+    """Test the mc_nbfx_decoder function with another real-world example."""
+    nbfx_message = (
+        b"@\x06string\x083http://schemas.microsoft.com/2003/10/Serialization/"
+        b'\x9a\x87\x01{"DeviceId":"ZAP000000","DeviceType":4,'
+        b'"ChargerId":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","StateId":554,'
+        b'"Timestamp":"2023-08-03T00:00:00.0617Z","ValueAsString":"OCMF|'
+        b'{\\"FV\\":\\"1.0\\",\\"GI\\":\\"ZAPTEC GO\\",'
+        b'\\"GS\\":\\"ZAP000000\\",\\"GV\\":\\"2.1.0.4\\",\\"PG\\":\\"F1\\",'
+        b'\\"RD\\":[{\\"TM\\":\\"2023-08-03T00:00:00,000+00:00 R\\",'
+        b'\\"RV\\":179.715,\\"RI\\":\\"1-0:1.8.0\\",\\"RU\\":\\"kWh\\",'
+        b'\\"RT\\":\\"AC\\",\\"ST\\":\\"G\\"}]}"}\x01'
+    )
+
+    expected_output = [
+        {
+            "name": "string",
+            "text": (
+                '{"DeviceId":"ZAP000000","DeviceType":4,'
+                '"ChargerId":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","StateId":554,'
+                '"Timestamp":"2023-08-03T00:00:00.0617Z","ValueAsString":"OCMF|'
+                '{\\"FV\\":\\"1.0\\",\\"GI\\":\\"ZAPTEC GO\\",'
+                '\\"GS\\":\\"ZAP000000\\",\\"GV\\":\\"2.1.0.4\\",\\"PG\\":\\"F1\\",'
+                '\\"RD\\":[{\\"TM\\":\\"2023-08-03T00:00:00,000+00:00 R\\",'
+                '\\"RV\\":179.715,\\"RI\\":\\"1-0:1.8.0\\",\\"RU\\":\\"kWh\\",'
+                '\\"RT\\":\\"AC\\",\\"ST\\":\\"G\\"}]}"}'
+            ),
+            "xmlns": "http://schemas.microsoft.com/2003/10/Serialization/",
+        }
+    ]
+
+    result = mc_nbfx_decoder(nbfx_message)
+    assert result == expected_output, f"Expected {expected_output}, got {result}"
+
+
+def test_misc_to_under() -> None:
+    """Test the to_under function."""
+    assert to_under("HelloWorld") == "hello_world"
+    assert to_under("helloWorld") == "hello_world"
+    assert to_under("Hello") == "hello"
+    assert to_under("H") == "h"
+    assert to_under("") == ""
+    assert to_under("ThisIsATest") == "this_is_a_test"
+    assert to_under("already_under") == "already_under"
+    assert to_under("with123Numbers") == "with123_numbers"
+    assert to_under("with_Special$Chars!") == "with_special$chars!"


### PR DESCRIPTION
This PR contains the cleanup of zaptec/misc.py. All ruff errors have been removed (and even some caught by the pyright static type checker) and tests for the functions have been added.