### PR TITLE
Fix TypeError-crash for users without access to Hierarchy-endpoint

### DIFF
--- a/custom_components/zaptec/zaptec/api.py
+++ b/custom_components/zaptec/zaptec/api.py
@@ -238,6 +238,8 @@ class Installation(ZaptecBase):
         try:
             hierarchy = await self.zaptec.request(f"installation/{self.id}/hierarchy")
             if not hierarchy:
+                # 2025-09-19: It appears Zaptec started returning HTTPStatus.NO_CONTENT instead of
+                # HTTPStatus.FORBIDDEN when user doesn't have access.
                 _LOGGER.warning(
                     ("No hierarchy returned for installation %s. The user might not have access"),
                     self.qual_id,

--- a/custom_components/zaptec/zaptec/api.py
+++ b/custom_components/zaptec/zaptec/api.py
@@ -237,6 +237,13 @@ class Installation(ZaptecBase):
         # Get the hierarchy of circurits and chargers
         try:
             hierarchy = await self.zaptec.request(f"installation/{self.id}/hierarchy")
+            if not hierarchy:
+                _LOGGER.warning(
+                    ("No hierarchy returned for installation %s. The user might not have access"),
+                    self.qual_id,
+                )
+                self.chargers = []
+                return
         except RequestError as err:
             if err.error_code == HTTPStatus.FORBIDDEN:
                 _LOGGER.warning(


### PR DESCRIPTION
Handle a 204(no content)-response the same way we have handled a 403-response previously.

Fixes #320