### PR TITLE
Skip attribute initialisation when firmware info is missing

### DIFF
--- a/custom_components/zaptec/zaptec/api.py
+++ b/custom_components/zaptec/zaptec/api.py
@@ -324,7 +324,10 @@ class Installation(ZaptecBase):
                 ):
                     # If the charger is already added to the Zaptec platform but not yet
                     # initialized, these fields are not available.
-                    _LOGGER.warning("Missing firmware info for charger %s", charger.qual_id)
+                    _LOGGER.warning(
+                        "Missing firmware info for charger %s because the charger hasn't been initialized yet. Safe to ignore.",  # noqa: E501
+                        charger.qual_id,
+                    )
                     continue
 
                 charger.set_attributes(


### PR DESCRIPTION
Skip attributes and add warning for missing firmware info in charger attributes, prevents the integration from crashing while starting, if these attributes are not available.

This only happens for chargers that are added to the Zaptec portal, but not configured or correctly added.