### PR TITLE
Remove incorrect or too restrictive validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.8.6 (draft)
 
-- Fixes issue where calls to the localSettings-API triggered an error on validating the response
+This is a minor release that fixes a validation issue that caused the integration to stop working for users with at least one charger they only have the User role for.
+
+In addition, it also fixes an issue where calls to the localSettings-API triggered an error on validating the response.
 
 ## 0.8.5
 

--- a/custom_components/zaptec/zaptec/validate.py
+++ b/custom_components/zaptec/zaptec/validate.py
@@ -17,7 +17,6 @@ class Installation(BaseModel):
     model_config = ConfigDict(extra="allow")
     Id: str
     Active: bool
-    AuthenticationType: int
     CurrentUserRoles: int
     InstallationType: int
     NetworkType: int


### PR DESCRIPTION
Validation of ChargerLocalSettings-response:
We don't use the response for anything, and it is an undocumented API, so we shouldn't require any validation.

Validation of Installation(s)-response:
Users without the Owner role don't get the full installation object, specifically not the AuthenticationType-entry that was in the validation. Since the Installations-response includes all installations the user has access to, not just the one(s) they have added to HA, that causes issues. Since we don't use Authentication type for anything (other than displaying it in a sensor), we can just remove the requirement.

Fixes #354. Fixes #357 