### PR TITLE
Update devcontainer and unit tests to python 3.14

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Zaptec integration development",
-    "image": "mcr.microsoft.com/devcontainers/python:3.13",
+    "image": "mcr.microsoft.com/devcontainers/python:3.14",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [
         8123
@@ -37,7 +37,7 @@
                 "files.trimTrailingWhitespace": true,
                 "python.analysis.autoImportCompletions": true,
                 "python.analysis.extraPaths": [
-                    "/home/vscode/.local/lib/python3.13/site-packages"
+                    "/home/vscode/.local/lib/python3.14/site-packages"
                 ],
                 "python.analysis.typeCheckingMode": "basic",
                 "python.defaultInterpreterPath": "/usr/local/bin/python"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -79,14 +79,17 @@ jobs:
   tests:
     name: Unit testing
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.13", "3.14"] # If 3.13-tests start failing, we need to consider setting HA2026.3 as the minimum version.
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
-      - name: Setup Python
+      - name: Setup Python ${{ matrix.python-version }}
         uses: "actions/setup-python@v5"
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install requirements
         run: |

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -91,6 +91,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Revert HA requirement to last version supporting Python ${{ matrix.python-version }}
+        if: matrix.python-version == '3.13'
+        run: |
+          sed -i 's/^homeassistant==.*/homeassistant==2026.2.3/' requirements.txt
+
       - name: Install requirements
         run: |
           pip install \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 colorlog==6.10.1
-homeassistant==2026.2.3
+homeassistant==2026.4.1
 pip>=25.0
-ruff==0.15.4
+ruff==0.15.9
 
 # Copy from manifest.json to get this into the dev container
 # without needing to start HA


### PR DESCRIPTION
Since 2026.3, HomeAssistant is shipped with python 3.14 