### PR TITLE
Update github actions versions to newest version to support Node.js 24

### DIFF
--- a/.github/workflows/monitor-requirements.yaml
+++ b/.github/workflows/monitor-requirements.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout zaptec repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check manifest requirements against latest HA dev branch
         run: |

--- a/.github/workflows/monitor-requirements.yaml
+++ b/.github/workflows/monitor-requirements.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout zaptec repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check manifest requirements against latest HA dev branch
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: ZIP the integration directory
         run: |
@@ -23,6 +23,6 @@ jobs:
           zip zaptec.zip -r ./
 
       - name: Upload the ZIP file to the release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ github.workspace }}/custom_components/zaptec/zaptec.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: ZIP the integration directory
         run: |
@@ -23,6 +23,6 @@ jobs:
           zip zaptec.zip -r ./
 
       - name: Upload the ZIP file to the release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           files: ${{ github.workspace }}/custom_components/zaptec/zaptec.zip

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run hassfest validation
         uses: home-assistant/actions/hassfest@master
@@ -36,16 +36,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run ruff format
-        uses: astral-sh/ruff-action@v4
+        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
           args: format --diff
           src: "."
 
       - name: Run ruff check
-        uses: astral-sh/ruff-action@v4
+        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
           args: check --exit-zero # succeed despite errors until https://github.com/custom-components/zaptec/issues/258 is done
           src: "."
@@ -55,14 +55,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout zaptec repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check manifest requirements against latest HA dev branch
         run: |
           cd ${{ github.workspace }}
           python3 scripts/check_requirements.py --current-ha-dev
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -84,10 +84,10 @@ jobs:
         python-version: ["3.13", "3.14"] # If 3.13-tests start failing, we need to consider setting HA2026.3 as the minimum version.
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: "actions/setup-python@v6"
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run hassfest validation
         uses: home-assistant/actions/hassfest@master
@@ -36,16 +36,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run ruff format
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4
         with:
           args: format --diff
           src: "."
 
       - name: Run ruff check
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4
         with:
           args: check --exit-zero # succeed despite errors until https://github.com/custom-components/zaptec/issues/258 is done
           src: "."
@@ -55,14 +55,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout zaptec repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check manifest requirements against latest HA dev branch
         run: |
           cd ${{ github.workspace }}
           python3 scripts/check_requirements.py --current-ha-dev
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -84,10 +84,10 @@ jobs:
         python-version: ["3.13", "3.14"] # If 3.13-tests start failing, we need to consider setting HA2026.3 as the minimum version.
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: "actions/setup-python@v5"
+        uses: "actions/setup-python@v6"
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
From warning message on various actions:

Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see:  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/