### PR TITLE
Add LockMotorCurrents to CHARGER_EXCLUDES

### DIFF
--- a/custom_components/zaptec/zaptec/const.py
+++ b/custom_components/zaptec/zaptec/const.py
@@ -49,6 +49,7 @@ FALSY = ["false", "0", "off", "no", 0, False]
 # attributes. Use strings.
 CHARGER_EXCLUDES = {
     "854",  # PilotTestResults
+    "877",  # LockMotorCurrents
     "900",  # ProductionTestResults
     "980",  # MIDCalibration
 }


### PR DESCRIPTION
In the HA logs, there are lines line:
WARNING (Recorder) [homeassistant.components.recorder.db_schema] State attributes for binary_sensor.zaptec_go_2_charger exceed maximum size of 16384 bytes. This can cause database performance issues; Attributes will not be stored

The 'LockMotorCurrents' attribute consumes ~65% of the total size.  
Excluding this item from the attributes solves the warnings.