### PR TITLE
Fix reportIncompatibleVariableOverride type errors in platform entities

### DIFF
--- a/custom_components/zaptec/binary_sensor.py
+++ b/custom_components/zaptec/binary_sensor.py
@@ -46,8 +46,6 @@ class ZaptecBinarySensorWithAttrs(ZaptecBinarySensor):
 class ZapBinarySensorEntityDescription(ZaptecEntityDescription, BinarySensorEntityDescription):
     """Class describing Zaptec binary sensor entities."""
 
-    cls: type[BinarySensorEntity]
-
 
 INSTALLATION_ENTITIES: list[ZaptecEntityDescription] = [
     ZapBinarySensorEntityDescription(

--- a/custom_components/zaptec/button.py
+++ b/custom_components/zaptec/button.py
@@ -18,10 +18,8 @@ from .zaptec import Charger
 _LOGGER = logging.getLogger(__name__)
 
 
-class ZaptecButton(ZaptecBaseEntity, ButtonEntity):
+class ZaptecButton(ZaptecBaseEntity[Charger], ButtonEntity):
     """Base class for Zaptec buttons."""
-
-    zaptec_obj: Charger
 
     @property
     def available(self) -> bool:
@@ -47,8 +45,6 @@ class ZaptecButton(ZaptecBaseEntity, ButtonEntity):
 @dataclass(frozen=True, kw_only=True)
 class ZapButtonEntityDescription(ZaptecEntityDescription, ButtonEntityDescription):
     """Class describing Zaptec button entities."""
-
-    cls: type[ButtonEntity]
 
 
 INSTALLATION_ENTITIES: list[ZaptecEntityDescription] = []

--- a/custom_components/zaptec/entity.py
+++ b/custom_components/zaptec/entity.py
@@ -26,12 +26,13 @@ class KeyUnavailableError(Exception):
         self.key = key
 
 
-class ZaptecBaseEntity(CoordinatorEntity[ZaptecUpdateCoordinator]):
+class ZaptecBaseEntity[ZaptecObjectT: ZaptecBase = ZaptecBase](
+    CoordinatorEntity[ZaptecUpdateCoordinator]
+):
     """Base class for Zaptec entities."""
 
     coordinator: ZaptecUpdateCoordinator
-    zaptec_obj: ZaptecBase
-    entity_description: EntityDescription
+    zaptec_obj: ZaptecObjectT
     _attr_has_entity_name = True
     _prev_value: Any = MISSING
     _prev_available: bool = True  # Assume the entity is available at start for logging
@@ -41,7 +42,7 @@ class ZaptecBaseEntity(CoordinatorEntity[ZaptecUpdateCoordinator]):
     def __init__(
         self,
         coordinator: ZaptecUpdateCoordinator,
-        zaptec_object: ZaptecBase,
+        zaptec_object: ZaptecObjectT,
         description: EntityDescription,
         device_info: DeviceInfo,
     ) -> None:

--- a/custom_components/zaptec/manager.py
+++ b/custom_components/zaptec/manager.py
@@ -8,6 +8,7 @@ import contextlib
 from copy import copy
 from dataclasses import dataclass
 import logging
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -28,7 +29,7 @@ type ZaptecConfigEntry = ConfigEntry[ZaptecManager]
 class ZaptecEntityDescription(EntityDescription):
     """Class describing Zaptec entities."""
 
-    cls: type[ZaptecBaseEntity]
+    cls: type[ZaptecBaseEntity[Any]]
 
 
 class ZaptecManager:
@@ -107,7 +108,7 @@ class ZaptecManager:
 
             # Use provided class if it exists, otherwise use the class this
             # function was called from
-            cls: type[ZaptecBaseEntity] = description.cls
+            cls: type[ZaptecBaseEntity[Any]] = description.cls
             entity = cls(
                 coordinator=self.device_coordinators[zaptec_obj.id],
                 zaptec_object=zaptec_obj,

--- a/custom_components/zaptec/number.py
+++ b/custom_components/zaptec/number.py
@@ -18,12 +18,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import ZaptecBaseEntity
 from .manager import ZaptecConfigEntry, ZaptecEntityDescription
-from .zaptec import Charger, Installation
+from .zaptec import Charger, Installation, ZaptecBase
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class ZaptecNumber(ZaptecBaseEntity, NumberEntity):
+class ZaptecNumber[ZaptecObjectT: ZaptecBase](ZaptecBaseEntity[ZaptecObjectT], NumberEntity):
     """Base class for Zaptec number entities."""
 
     # What to log on entity update
@@ -48,10 +48,9 @@ class ZaptecNumber(ZaptecBaseEntity, NumberEntity):
         )
 
 
-class ZaptecAvailableCurrentNumber(ZaptecNumber):
+class ZaptecAvailableCurrentNumber(ZaptecNumber[Installation]):
     """Zaptec available current number entity."""
 
-    zaptec_obj: Installation
     entity_description: ZapNumberEntityDescription
 
     def _post_init(self) -> None:
@@ -72,10 +71,9 @@ class ZaptecAvailableCurrentNumber(ZaptecNumber):
         await self.trigger_poll()
 
 
-class ZaptecThreeToOnePhaseSwitchCurrent(ZaptecNumber):
+class ZaptecThreeToOnePhaseSwitchCurrent(ZaptecNumber[Installation]):
     """Zaptec three to one phase switch current number entity."""
 
-    zaptec_obj: Installation
     entity_description: ZapNumberEntityDescription
 
     async def async_set_native_value(self, value: float) -> None:
@@ -91,10 +89,9 @@ class ZaptecThreeToOnePhaseSwitchCurrent(ZaptecNumber):
         await self.trigger_poll()
 
 
-class ZaptecSettingNumber(ZaptecNumber):
+class ZaptecSettingNumber(ZaptecNumber[Charger]):
     """Zaptec setting number entity."""
 
-    zaptec_obj: Charger
     entity_description: ZapNumberEntityDescription
 
     def _post_init(self) -> None:
@@ -119,10 +116,9 @@ class ZaptecSettingNumber(ZaptecNumber):
         await self.trigger_poll()
 
 
-class ZaptecHmiBrightness(ZaptecNumber):
+class ZaptecHmiBrightness(ZaptecNumber[Charger]):
     """Zaptec HMI brightness number entity."""
 
-    zaptec_obj: Charger
     entity_description: ZapNumberEntityDescription
     _log_attribute = "_attr_native_value"
 
@@ -148,7 +144,6 @@ class ZaptecHmiBrightness(ZaptecNumber):
 class ZapNumberEntityDescription(ZaptecEntityDescription, NumberEntityDescription):
     """Class describing Zaptec number entities."""
 
-    cls: type[NumberEntity]
     setting: str | None = None
 
 

--- a/custom_components/zaptec/sensor.py
+++ b/custom_components/zaptec/sensor.py
@@ -133,8 +133,6 @@ class ZaptecEnengySensor(ZaptecSensor):
 class ZapSensorEntityDescription(ZaptecEntityDescription, SensorEntityDescription):
     """Provide a description of a Zaptec sensor."""
 
-    cls: type[SensorEntity]
-
 
 INSTALLATION_ENTITIES: list[ZaptecEntityDescription] = [
     ZapSensorEntityDescription(

--- a/custom_components/zaptec/switch.py
+++ b/custom_components/zaptec/switch.py
@@ -23,7 +23,7 @@ from .zaptec import Charger
 _LOGGER = logging.getLogger(__name__)
 
 
-class ZaptecSwitch(ZaptecBaseEntity, SwitchEntity):
+class ZaptecSwitch(ZaptecBaseEntity[Charger], SwitchEntity):
     """Base class for Zaptec switches."""
 
     # What to log on entity update
@@ -40,7 +40,6 @@ class ZaptecSwitch(ZaptecBaseEntity, SwitchEntity):
 class ZaptecChargeSwitch(ZaptecSwitch):
     """Zaptec charge switch entity."""
 
-    zaptec_obj: Charger
     _log_attribute = "_attr_is_on"
 
     @property
@@ -91,8 +90,6 @@ class ZaptecChargeSwitch(ZaptecSwitch):
 class ZaptecCableLockSwitch(ZaptecSwitch):
     """Zaptec cable lock entity."""
 
-    zaptec_obj: Charger
-
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Unlock the cable lock."""
         _LOGGER.debug(
@@ -127,8 +124,6 @@ class ZaptecCableLockSwitch(ZaptecSwitch):
 @dataclass(frozen=True, kw_only=True)
 class ZapSwitchEntityDescription(ZaptecEntityDescription, SwitchEntityDescription):
     """Class describing Zaptec switch entities."""
-
-    cls: type[SwitchEntity]
 
 
 INSTALLATION_ENTITIES: list[ZaptecEntityDescription] = []

--- a/custom_components/zaptec/update.py
+++ b/custom_components/zaptec/update.py
@@ -23,14 +23,13 @@ from .zaptec import Charger
 _LOGGER = logging.getLogger(__name__)
 
 
-class ZaptecUpdate(ZaptecBaseEntity, UpdateEntity):
+class ZaptecUpdate(ZaptecBaseEntity[Charger], UpdateEntity):
     """Base class for Zaptec update entities."""
 
     # What to log on entity update
     _log_attribute = "_attr_installed_version"
     # This entity use several attributes from Zaptec
     _log_zaptec_key: Final = ["firmware_current_version", "firmware_available_version"]
-    zaptec_obj: Charger
 
     @callback
     def _update_from_zaptec(self) -> None:
@@ -59,8 +58,6 @@ class ZaptecUpdate(ZaptecBaseEntity, UpdateEntity):
 @dataclass(frozen=True, kw_only=True)
 class ZapUpdateEntityDescription(ZaptecEntityDescription, UpdateEntityDescription):
     """Class describing Zaptec update entities."""
-
-    cls: type[UpdateEntity]
 
 
 INSTALLATION_ENTITIES: list[ZaptecEntityDescription] = []


### PR DESCRIPTION
## Problem

The entity platform modules (`switch.py`, `sensor.py`, `number.py`, `button.py`, `binary_sensor.py`, `update.py`) produced **31 near-identical `reportIncompatibleVariableOverride` errors** in Pylance/pyright (default `standard` mode). They came in three repeating shapes:

1. **`zaptec_obj` narrowing (8):** `ZaptecBaseEntity` declares `zaptec_obj: ZaptecBase`; subclasses redeclared it as `Charger`/`Installation`. Because a plain class attribute is mutable, its type is invariant, so narrowing it in a subclass is flagged as an incompatible override.
2. **`entity_description` diamond + narrowing (11):** `ZaptecBaseEntity` redeclared `entity_description: EntityDescription`, which conflicts with the HA platform mixin's own narrower `entity_description` (e.g. `SwitchEntity.entity_description: SwitchEntityDescription`) in the `class ZaptecX(ZaptecBaseEntity, HAEntity)` diamond, and the leaf redeclarations were flagged as narrowing overrides too.
3. **`cls` narrowing (6):** each `ZapXEntityDescription` redeclared `cls: type[SwitchEntity]` / `type[SensorEntity]` / etc. Those types are **not** subtypes of the base's `cls: type[ZaptecBaseEntity]`, so every one was an incompatible (and actually incorrect) override.

These were pure typing errors — the integration ran fine — but they cluttered the editor with red squiggles across every platform file.

## What changed and why

**1. Make `ZaptecBaseEntity` generic over the Zaptec object type.**
`class ZaptecBaseEntity[ZaptecObjectT: ZaptecBase = ZaptecBase]` with `zaptec_obj: ZaptecObjectT`. Subclasses now narrow by parametrizing the base (`ZaptecBaseEntity[Charger]`, `ZaptecNumber[Installation]`, …) instead of redeclaring `zaptec_obj`. This is the idiomatic fix — the same pattern HA core uses for coordinator entities — and removes all 8 `zaptec_obj` errors with **no suppressions**. Generics are erased at runtime, so there is no behavioural change.

**2. Drop the redundant `entity_description: EntityDescription` from `ZaptecBaseEntity`.**
HA's `Entity` already declares `entity_description: EntityDescription`, so the base class inherits it and typing still resolves. Removing our redeclaration clears the base-vs-mixin diamond conflicts and the leaf narrowing errors.

**3. Remove the mistyped `cls: type[XEntity]` redeclarations** in the `ZapXEntityDescription` dataclasses. They now inherit the correct `cls: type[ZaptecBaseEntity[Any]]` from `ZaptecEntityDescription` (widened from `type[ZaptecBaseEntity]` so any generic parametrization is accepted). The `cls` dataclass field is still present (verified at runtime).

### Result

Platform-file errors: **31 → 6**, zero new errors, zero `# type: ignore`.

The remaining 6 are `available` diamond conflicts (`CoordinatorEntity.available` property vs `Entity.available` cached_property) that are inherent to *every* HA coordinator-based entity and are deliberately left untouched rather than papered over.

## Testing

- `ruff check custom_components tests` — clean on the touched files.
- `ruff format custom_components tests --diff` — clean.
- `pytest tests` (with `SKIP_ZAPTEC_API_TEST=true`) — **10 passed, 2 skipped**; the only errors are the pre-existing `test_zconst.py`/`test_redact.py` cases that require live access to `api.zaptec.com` and are unrelated to this change.
- Runtime smoke check: all platform modules import, MRO is intact, and the `cls` dataclass field is still present after the refactor.

## Notes

No functional/behavioural changes — this is a types-only cleanup. Net diff: 8 files, +17 / -36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)