### PR TITLE
Remove state attributes from the active binary sensors

### DIFF
--- a/custom_components/zaptec/binary_sensor.py
+++ b/custom_components/zaptec/binary_sensor.py
@@ -34,11 +34,14 @@ class ZaptecBinarySensor(ZaptecBaseEntity, BinarySensorEntity):
         self._attr_available = True
 
 
-class ZaptecBinarySensorWithAttrs(ZaptecBinarySensor):
-    """Zaptec binary sensor with additional attributes."""
+class ZaptecActiveBinarySensor(ZaptecBinarySensor):
+    """Zaptec 'active' binary sensor for the main charger/installation device.
+
+    Uses the bare Zaptec object id as the unique id (without the entity key
+    suffix) to preserve the historical entity identity.
+    """
 
     def _post_init(self) -> None:
-        self._attr_extra_state_attributes = self.zaptec_obj.asdict()
         self._attr_unique_id = self.zaptec_obj.id
 
 
@@ -55,7 +58,7 @@ INSTALLATION_ENTITIES: list[ZaptecEntityDescription] = [
         entity_category=const.EntityCategory.DIAGNOSTIC,
         icon="mdi:cloud",
         has_entity_name=False,
-        cls=ZaptecBinarySensorWithAttrs,
+        cls=ZaptecActiveBinarySensor,
     ),
     ZapBinarySensorEntityDescription(
         # The Zaptec API is not consistent with the naming of the usage of
@@ -77,7 +80,7 @@ CHARGER_ENTITIES: list[ZaptecEntityDescription] = [
         entity_category=const.EntityCategory.DIAGNOSTIC,
         icon="mdi:cloud",
         has_entity_name=False,
-        cls=ZaptecBinarySensorWithAttrs,
+        cls=ZaptecActiveBinarySensor,
     ),
     ZapBinarySensorEntityDescription(
         key="is_online",

--- a/custom_components/zaptec/manager.py
+++ b/custom_components/zaptec/manager.py
@@ -173,7 +173,9 @@ class ZaptecManager:
                 )
 
             elif isinstance(obj, Charger):
-                info = DeviceInfo()
+                # Expose the Zaptec device id as the device serial number, matching
+                # what the Zaptec app shows as the charger serial.
+                info = DeviceInfo(serial_number=obj.get("DeviceId"))
                 if obj.installation:
                     info["via_device"] = (DOMAIN, obj.installation.id)
 


### PR DESCRIPTION
Removes the `extra_state_attributes` dump from the charger and installation `active` binary sensors.

**Why**
- The attribute blob changes on nearly every poll and can exceed HA's 16 KB limit → recorder `exceed maximum size of 16384 bytes` warnings (#382) and the likely cause of the companion-app black screen (#386).
- Minimizing frequently-changing attributes is HA best practice / likely a core requirement (#297).
- Nearly all values already have dedicated entities; the attributes have seen no real troubleshooting use.

**Also (non-breaking):** the charger's Zaptec `DeviceId` is now surfaced as the device **Serial number** in the device registry, matching the Zaptec app.

**⚠️ Breaking change:** the active charger/installation binary sensors no longer expose Zaptec fields as state attributes. Anything reading those attributes should switch to the dedicated entities.

Part of #297. Follow-up PR will add sensors for the few values that don't have an entity yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)