### PR TITLE
Add per-charger energy statistics feed to fix Energy Dashboard hour-misattribution (fixes #300)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ Confirmed to work with Zaptec products
   [here](https://www.home-assistant.io/common-tasks/general/#defining-a-custom-polling-interval),
   will have unexpected effects. If the automatic polling is turned off, not all
   the data in the integration will update properly.
-* Using the _Energy Meter_ entity as an input to the Energy Dashboard will give values that are delayed by 1 hour
-  in the graphs (see [issue 162](https://github.com/custom-components/zaptec/issues/162) for details).
-  There is a plan to solve this in [issue 300](https://github.com/custom-components/zaptec/issues/300), but until that is implemented,
-  a workaround is to use the more frequently updated _Session total charge_ entity instead. This reduces the delay-issue,
-  but has a separate drawback where a restart of Home Assistant during a charging session can give a fake spike in the logged
-  consumption that needs to be manually edited using "Adjust sum" in the Statistics tab of the Developer tools dashboard.
+* Using the _Energy Meter_ entity directly as an input to the Energy Dashboard will still give values delayed by up to an hour
+  in the graphs, since that entity reflects live (polling-delayed) state (see [issue 162](https://github.com/custom-components/zaptec/issues/162)).
+  Each tracked charger now also gets a separate, invisible statistics feed (backdated hourly from Zaptec's charge history,
+  see [issue 300](https://github.com/custom-components/zaptec/issues/300)) that appears in the Energy Dashboard's device picker
+  as "<charger name> Energy" - use that entry instead of _Energy Meter_ or _Session total charge_ for accurate,
+  correctly-timed consumption graphs.
 
 
 # Installation and setup

--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -25,9 +25,11 @@ from .const import (
 from .coordinator import ZaptecUpdateCoordinator, ZaptecUpdateOptions
 from .manager import ZaptecConfigEntry, ZaptecManager
 from .services import async_setup_services, async_unload_services
+from .statistics import ZaptecStatisticsCoordinator
 from .zaptec import (
     RETRYABLE_HTTP_STATUSES,
     AuthenticationError,
+    Charger,
     Installation,
     RequestConnectionError,
     RequestError,
@@ -184,8 +186,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ),
         )
 
+    # Setup the statistics coordinators, one per tracked charger, to backdate
+    # hourly energy consumption into HA's Energy Dashboard statistics (fixes
+    # the live sensor's misattributed-hour delay, see issue #300).
+    for deviceid in tracked_devices:
+        zaptec_obj = zaptec[deviceid]
+        if isinstance(zaptec_obj, Charger):
+            manager.statistics_coordinators[deviceid] = ZaptecStatisticsCoordinator(
+                hass, entry=entry, charger=zaptec_obj
+            )
+
     # Initialize the coordinators
     for co in manager.all_coordinators:
+        await co.async_config_entry_first_refresh()
+    for co in manager.statistics_coordinators.values():
         await co.async_config_entry_first_refresh()
 
     # Done setting up, change back to not log all updates. Having this enabled

--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -48,7 +48,8 @@ def _config_entry_error(
     and timeout errors, and transient server statuses (429/502/503/504), are
     recoverable, so we raise ConfigEntryNotReady to let Home Assistant retry
     setup automatically instead of failing permanently (issue #392). All other
-    API errors remain permanent ConfigEntryError failures."""
+    API errors remain permanent ConfigEntryError failures.
+    """
     if isinstance(err, AuthenticationError):
         return ConfigEntryAuthFailed(str(err))
     if isinstance(err, (RequestTimeoutError, RequestConnectionError)):

--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -26,15 +26,37 @@ from .coordinator import ZaptecUpdateCoordinator, ZaptecUpdateOptions
 from .manager import ZaptecConfigEntry, ZaptecManager
 from .services import async_setup_services, async_unload_services
 from .zaptec import (
+    RETRYABLE_HTTP_STATUSES,
     AuthenticationError,
     Installation,
     RequestConnectionError,
+    RequestError,
     RequestTimeoutError,
     Zaptec,
     ZaptecApiError,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _config_entry_error(
+    err: ZaptecApiError,
+) -> ConfigEntryAuthFailed | ConfigEntryNotReady | ConfigEntryError:
+    """Map a Zaptec API error from setup login to a HA config-entry error.
+
+    Authentication failures are non-recoverable (trigger re-auth). Connection
+    and timeout errors, and transient server statuses (429/502/503/504), are
+    recoverable, so we raise ConfigEntryNotReady to let Home Assistant retry
+    setup automatically instead of failing permanently (issue #392). All other
+    API errors remain permanent ConfigEntryError failures."""
+    if isinstance(err, AuthenticationError):
+        return ConfigEntryAuthFailed(str(err))
+    if isinstance(err, (RequestTimeoutError, RequestConnectionError)):
+        return ConfigEntryNotReady(str(err))
+    if isinstance(err, RequestError) and err.error_code in RETRYABLE_HTTP_STATUSES:
+        return ConfigEntryNotReady(str(err))
+    return ConfigEntryError(str(err))
+
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -80,15 +102,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Login to the Zaptec account
     try:
         await zaptec.login()
-    except AuthenticationError as err:
-        _LOGGER.error("Authentication failed: %s", err)
-        raise ConfigEntryAuthFailed from err
-    except (RequestTimeoutError, RequestConnectionError) as err:
-        _LOGGER.error("Connection error: %s", err)
-        raise ConfigEntryNotReady from err
     except ZaptecApiError as err:
-        _LOGGER.error("Zaptec API error: %s", err)
-        raise ConfigEntryError from err
+        _LOGGER.error("Zaptec login failed: %s", err)
+        raise _config_entry_error(err) from err
 
     # Get the structure of devices from Zaptec and determine the zaptec objects to track
     tracked_devices = await ZaptecManager.first_time_setup(

--- a/custom_components/zaptec/__init__.py
+++ b/custom_components/zaptec/__init__.py
@@ -199,8 +199,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Initialize the coordinators
     for co in manager.all_coordinators:
         await co.async_config_entry_first_refresh()
+    # First-refresh the statistics coordinators with async_refresh() (not
+    # async_config_entry_first_refresh()) - the latter turns any failure into
+    # ConfigEntryNotReady, aborting setup of the *entire* integration (every
+    # sensor/switch/button) over a hiccup on this secondary, Owner-only
+    # endpoint. async_refresh() logs and marks the coordinator unavailable
+    # instead, so a charge-history outage only degrades the Energy Dashboard
+    # feed, not the whole config entry.
     for co in manager.statistics_coordinators.values():
-        await co.async_config_entry_first_refresh()
+        await co.async_refresh()
 
     # Done setting up, change back to not log all updates. Having this enabled
     # will create a lot of debug log output.

--- a/custom_components/zaptec/const.py
+++ b/custom_components/zaptec/const.py
@@ -51,3 +51,9 @@ KEYS_TO_SKIP_ENTITY_AVAILABILITY_CHECK = {
     "three_to_one_phase_switch_current",
     "total_charge_power_session",
 }
+
+ZAPTEC_STATISTICS_POLL_INTERVAL = 60 * 60
+"""Interval in seconds between imports of archived charge sessions into HA statistics."""
+
+ZAPTEC_STATISTICS_BACKFILL_DAYS = 730
+"""How far back (in days) to backfill energy statistics on first import."""

--- a/custom_components/zaptec/manager.py
+++ b/custom_components/zaptec/manager.py
@@ -18,6 +18,7 @@ from homeassistant.util.ssl import get_default_context
 from .const import DOMAIN, KEYS_TO_SKIP_ENTITY_AVAILABILITY_CHECK, MANUFACTURER
 from .coordinator import ZaptecUpdateCoordinator
 from .entity import KeyUnavailableError, ZaptecBaseEntity
+from .statistics import ZaptecStatisticsCoordinator
 from .zaptec import Charger, Installation, Zaptec, ZaptecBase
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,6 +54,9 @@ class ZaptecManager:
     device_coordinators: dict[str, ZaptecUpdateCoordinator]
     """Coordinators for the devices, both installation and chargers."""
 
+    statistics_coordinators: dict[str, ZaptecStatisticsCoordinator]
+    """Coordinators that backdate hourly energy statistics, one per tracked charger."""
+
     streams: list[tuple[asyncio.Task, Installation]]
     """List of active streams for the installations."""
 
@@ -72,6 +76,7 @@ class ZaptecManager:
         self.tracked_devices = tracked_devices or set()
         self.name_prefix = name_prefix
         self.device_coordinators = {}
+        self.statistics_coordinators = {}
         self.streams = []
 
     @property

--- a/custom_components/zaptec/manifest.json
+++ b/custom_components/zaptec/manifest.json
@@ -6,7 +6,9 @@
     "@hellowlol"
   ],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": [
+    "recorder"
+  ],
   "documentation": "https://github.com/custom-components/zaptec",
   "integration_type": "hub",
   "iot_class": "cloud_polling",

--- a/custom_components/zaptec/services.yaml
+++ b/custom_components/zaptec/services.yaml
@@ -73,7 +73,7 @@ restart_charger:
       description: Charger identifier
       example: 00000000-1111-2222-3333-444444444444
 
-update_firmware:
+upgrade_firmware:
   name: Update firmware
   description: >-
     Send update firmware request to the charger. Select charger

--- a/custom_components/zaptec/statistics.py
+++ b/custom_components/zaptec/statistics.py
@@ -3,21 +3,11 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
 from homeassistant.components.recorder.models import StatisticData
 from homeassistant.util import dt as dt_util
-
-
-@dataclass
-class _StatisticDataWrapper:
-    """Wrapper for StatisticData that supports attribute access while maintaining type compatibility."""
-
-    start: datetime
-    state: float
-    sum: float
 
 
 def _floor_hour(value: datetime) -> datetime:
@@ -83,7 +73,5 @@ def bucket_sessions_hourly(
     statistics: list[StatisticData] = []
     for hour in sorted(hourly_deltas):
         running_sum += hourly_deltas[hour]
-        statistics.append(
-            _StatisticDataWrapper(start=hour, state=hourly_deltas[hour], sum=running_sum)
-        )  # type: ignore[assignment]
+        statistics.append(StatisticData(start=hour, state=hourly_deltas[hour], sum=running_sum))
     return statistics

--- a/custom_components/zaptec/statistics.py
+++ b/custom_components/zaptec/statistics.py
@@ -9,6 +9,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.recorder import get_instance
+from homeassistant.components.recorder.db_schema import StatisticsMeta
 from homeassistant.components.recorder.models import (
     StatisticData,
     StatisticMeanType,
@@ -40,6 +41,12 @@ so a session that closes slightly before our nominal `From` cutoff - but
 still has energy points after it - would otherwise be missed. Correctness is
 enforced by bucket_sessions_hourly()'s own `after` filter regardless; this is
 purely a fetch-window optimization to avoid re-scanning all of history."""
+
+_SUPPORTS_UNIT_CLASS = hasattr(StatisticsMeta, "unit_class")
+"""Whether the installed HA core's StatisticsMeta accepts unit_class - absent
+on HA < ~2026, a required kwarg (with a deprecation warning if omitted) as of
+2026.4.3, moving to a hard requirement in HA 2026.11. Feature-detected rather
+than version-compared since the exact introduction version isn't pinned down."""
 
 
 def _floor_hour(value: datetime) -> datetime:
@@ -194,13 +201,15 @@ class ZaptecStatisticsCoordinator(DataUpdateCoordinator[None]):
         if not statistics:
             return
 
-        metadata = StatisticMetaData(
-            mean_type=StatisticMeanType.NONE,
-            has_sum=True,
-            name=f"{self.charger.name} Energy",
-            source=DOMAIN,
-            statistic_id=self.statistic_id,
-            unit_class=EnergyConverter.UNIT_CLASS,
-            unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        )
+        metadata_kwargs: dict[str, Any] = {
+            "mean_type": StatisticMeanType.NONE,
+            "has_sum": True,
+            "name": f"{self.charger.name} Energy",
+            "source": DOMAIN,
+            "statistic_id": self.statistic_id,
+            "unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
+        }
+        if _SUPPORTS_UNIT_CLASS:
+            metadata_kwargs["unit_class"] = EnergyConverter.UNIT_CLASS
+        metadata = StatisticMetaData(**metadata_kwargs)
         async_add_external_statistics(self.hass, metadata, statistics)

--- a/custom_components/zaptec/statistics.py
+++ b/custom_components/zaptec/statistics.py
@@ -55,8 +55,8 @@ def bucket_sessions_hourly(
 ) -> list[StatisticData]:
     """Convert archived charge sessions into hourly external-statistics points.
 
-    Each session's `EnergyDetails` is a list of `{Timestamp, Energy}` points
-    where `Energy` is cumulative *within that session* (starts near 0). This
+    Each session's `energyDetails` is a list of `{timestamp, energy}` points
+    where `energy` is cumulative *within that session* (starts near 0). This
     turns those into per-hour consumption deltas, bucketed by the hour
     containing each point's timestamp. That's an approximation: a delta
     between two points less than an hour apart can span an hour boundary
@@ -65,9 +65,9 @@ def bucket_sessions_hourly(
     split proportionally. This is still a large accuracy improvement over the
     live sensor, which can lag by 1+ hour (upstream issue #300).
 
-    Sessions without `EnergyDetails` (e.g. pre-3.2 firmware) fall back to a
-    single point at `EndDateTime` using the session's total `Energy`. Sessions
-    marked `Voided` or `Aborted` are skipped entirely - per the API docs,
+    Sessions without `energyDetails` (e.g. pre-3.2 firmware) fall back to a
+    single point at `endDateTime` using the session's total `energy`. Sessions
+    marked `voided` or `aborted` are skipped entirely - per the API docs,
     "voided sessions have no meaningful duration or energy" (they exist when
     replaced by a corrected session, or when charging never actually started).
 
@@ -88,22 +88,22 @@ def bucket_sessions_hourly(
     hourly_deltas: dict[datetime, float] = defaultdict(float)
 
     for session in sessions:
-        if session.get("Voided") or session.get("Aborted"):
+        if session.get("voided") or session.get("aborted"):
             continue
 
-        details = session.get("EnergyDetails") or []
+        details = session.get("energyDetails") or []
         if not details:
-            end = session.get("EndDateTime")
-            energy = session.get("Energy") or 0.0
+            end = session.get("endDateTime")
+            energy = session.get("energy") or 0.0
             if end and energy:
-                details = [{"Timestamp": end, "Energy": energy}]
+                details = [{"timestamp": end, "energy": energy}]
 
         prev_energy = 0.0
         for point in details:
-            timestamp = dt_util.parse_datetime(point["Timestamp"])
+            timestamp = dt_util.parse_datetime(point["timestamp"])
             if timestamp is None:
                 continue
-            energy = point["Energy"]
+            energy = point["energy"]
             delta = energy - prev_energy
             prev_energy = energy
             hour = _floor_hour(timestamp)
@@ -171,10 +171,10 @@ class ZaptecStatisticsCoordinator(DataUpdateCoordinator[None]):
                     to_time=dt_util.utcnow(),
                     cursor=cursor,
                 )
-                sessions.extend(page.get("Sessions") or [])
-                if not page.get("HasMore"):
+                sessions.extend(page.get("sessions") or [])
+                if not page.get("hasMore"):
                     break
-                cursor = page.get("Cursor")
+                cursor = page.get("cursor")
         except RequestError as err:
             if err.error_code == HTTPStatus.FORBIDDEN:
                 # /api/sessions/archived requires the Owner role. Many Zaptec

--- a/custom_components/zaptec/statistics.py
+++ b/custom_components/zaptec/statistics.py
@@ -49,9 +49,26 @@ on HA < ~2026, a required kwarg (with a deprecation warning if omitted) as of
 than version-compared since the exact introduction version isn't pinned down."""
 
 
+_HOUR_BOUNDARY_TOLERANCE = timedelta(seconds=5)
+"""Snap window applied before flooring to an hour, to absorb clock/reporting
+jitter right at an hour boundary (e.g. a report meant to land at HH:00:00
+arriving at HH-1:59:58 or HH:00:03). Chosen well under Zaptec's observed
+reporting granularity (reports land within ~200ms of the hour in practice),
+so it can't bleed into a neighboring, genuinely different report."""
+
+
 def _floor_hour(value: datetime) -> datetime:
-    """Floor a datetime down to the start of its hour, in UTC."""
-    return dt_util.as_utc(value).replace(minute=0, second=0, microsecond=0)
+    """Floor a datetime down to the start of its hour, in UTC.
+
+    Rounds to the nearest hour first if `value` is within
+    `_HOUR_BOUNDARY_TOLERANCE` of one, so a report timestamped a few seconds
+    early or late doesn't land in the wrong hour bucket.
+    """
+    value = dt_util.as_utc(value)
+    floor = value.replace(minute=0, second=0, microsecond=0)
+    if value - floor >= timedelta(hours=1) - _HOUR_BOUNDARY_TOLERANCE:
+        floor += timedelta(hours=1)
+    return floor
 
 
 def bucket_sessions_hourly(
@@ -67,14 +84,32 @@ def bucket_sessions_hourly(
     point, not a cumulative running total (confirmed live 2026-07-12 by
     diffing a session's energyDetails against its own OCMF-signed
     sessionSignature meter readings - the two matched exactly once the OCMF
-    cumulative values were themselves differenced). This turns those points
-    into per-hour consumption, bucketed by the hour containing each point's
-    timestamp. That's an approximation: a delta between two points less than
-    an hour apart can span an hour boundary (Zaptec's default
-    meter-reporting interval is 30 minutes), so a small amount of energy can
-    be attributed to the following hour rather than split proportionally.
-    This is still a large accuracy improvement over the live sensor, which
-    can lag by 1+ hour (upstream issue #300).
+    cumulative values were themselves differenced).
+
+    Zaptec reports on a fixed hourly schedule while a session has metering
+    activity, but silently skips ticks while paused/idle - so the gap
+    between two points can be much longer than an hour. Live evidence
+    (2026-07-12: real energyDetails cross-checked against the charger's own
+    power sensor) showed that whenever a report follows such a gap, the
+    energy it carries almost always happened in the hour immediately
+    *before* that report, not spread across the whole gap and not at the
+    gap's start - e.g. a report at 14:00 following the previous report at
+    10:00 (a 4-hour gap) carried energy that the power sensor confirmed was
+    drawn around 13:00-13:24, not 10:00. So each point's delta is bucketed
+    by the hour immediately before its *own* timestamp - except a session's
+    final, irregularly-timed point (its real end, not a scheduled tick) must
+    not be walked back past the previous point's own hour, since that would
+    misattribute a normal end-of-session interval backwards. Both rules
+    collapse to the same answer for back-to-back hourly reports (no gap),
+    so this is a refinement of - not a reversal of - that case. The first
+    point in a session carries no delta to attribute (its `energy` is
+    always 0, marking session start) and has no previous point, so it's
+    bucketed by its own timestamp - harmless either way since it contributes
+    nothing. This is still an approximation for intervals that don't land on
+    a clean hour boundary (Zaptec's default meter-reporting interval is 30
+    minutes): the whole delta is attributed to a single hour rather than
+    split proportionally. This is still a large accuracy improvement over
+    the live sensor, which can lag by 1+ hour (upstream issue #300).
 
     Sessions without `energyDetails` (e.g. pre-3.2 firmware) fall back to a
     single point at `endDateTime` using the session's total `energy`. Sessions
@@ -109,12 +144,19 @@ def bucket_sessions_hourly(
             if end and energy:
                 details = [{"timestamp": end, "energy": energy}]
 
+        prev_timestamp: datetime | None = None
         for point in details:
             timestamp = dt_util.parse_datetime(point["timestamp"])
             if timestamp is None:
                 continue
             delta = point["energy"]
-            hour = _floor_hour(timestamp)
+            if prev_timestamp is None:
+                hour = _floor_hour(timestamp)
+            else:
+                hour = max(
+                    _floor_hour(timestamp) - timedelta(hours=1), _floor_hour(prev_timestamp)
+                )
+            prev_timestamp = timestamp
             if after is not None and hour <= after:
                 continue
             hourly_deltas[hour] += delta

--- a/custom_components/zaptec/statistics.py
+++ b/custom_components/zaptec/statistics.py
@@ -72,10 +72,18 @@ def bucket_sessions_hourly(
     replaced by a corrected session, or when charging never actually started).
 
     `sessions` must be sorted oldest-first (the archived-sessions API
-    guarantees this). Points at or before `after` are skipped, to avoid
-    double-counting data already imported by a previous run. `running_sum` is
-    the total energy (kWh) imported so far; the returned points chain onto it
-    so the statistic's `sum` keeps increasing monotonically.
+    guarantees this). `after` is the start of the last hour already imported
+    by a previous run (its `sum` already reflects that whole hour) - so any
+    point whose *floored hour* is at or before `after` is skipped, not just
+    points with a raw timestamp at or before `after`. Skipping by raw
+    timestamp would under-skip: a point at, say, 11:10 has a later raw
+    timestamp than `after=11:00` and would slip through, getting re-added to
+    an hour whose total was already stored - corrupting the external
+    statistic with compounding phantom energy on every subsequent poll,
+    since `/sessions/archived`'s `From` filter keeps returning the same
+    session until a newer one supersedes it as the resume point. `running_sum`
+    is the total energy (kWh) imported so far; the returned points chain onto
+    it so the statistic's `sum` keeps increasing monotonically.
     """
     hourly_deltas: dict[datetime, float] = defaultdict(float)
 
@@ -98,9 +106,10 @@ def bucket_sessions_hourly(
             energy = point["Energy"]
             delta = energy - prev_energy
             prev_energy = energy
-            if after is not None and timestamp <= after:
+            hour = _floor_hour(timestamp)
+            if after is not None and hour <= after:
                 continue
-            hourly_deltas[_floor_hour(timestamp)] += delta
+            hourly_deltas[hour] += delta
 
     statistics: list[StatisticData] = []
     for hour in sorted(hourly_deltas):
@@ -162,10 +171,10 @@ class ZaptecStatisticsCoordinator(DataUpdateCoordinator[None]):
                     to_time=dt_util.utcnow(),
                     cursor=cursor,
                 )
-                sessions.extend(page["Sessions"])
+                sessions.extend(page.get("Sessions") or [])
                 if not page.get("HasMore"):
                     break
-                cursor = page["Cursor"]
+                cursor = page.get("Cursor")
         except RequestError as err:
             if err.error_code == HTTPStatus.FORBIDDEN:
                 # /api/sessions/archived requires the Owner role. Many Zaptec

--- a/custom_components/zaptec/statistics.py
+++ b/custom_components/zaptec/statistics.py
@@ -3,11 +3,43 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from datetime import datetime
-from typing import Any
+from datetime import datetime, timedelta
+from http import HTTPStatus
+import logging
+from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.recorder.models import StatisticData
+from homeassistant.components.recorder import get_instance
+from homeassistant.components.recorder.models import (
+    StatisticData,
+    StatisticMeanType,
+    StatisticMetaData,
+)
+from homeassistant.components.recorder.statistics import (
+    async_add_external_statistics,
+    get_last_statistics,
+)
+from homeassistant.const import UnitOfEnergy
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_conversion import EnergyConverter
+
+from .const import DOMAIN, ZAPTEC_STATISTICS_BACKFILL_DAYS, ZAPTEC_STATISTICS_POLL_INTERVAL
+from .zaptec import Charger, RequestError, ZaptecApiError
+
+if TYPE_CHECKING:
+    from .manager import ZaptecConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+RESUME_MARGIN = timedelta(hours=26)
+"""Extra lookback window (beyond the last imported hour) when querying the API.
+
+/api/sessions/archived filters by session *end* time, not start time,
+so a session that closes slightly before our nominal `From` cutoff - but
+still has energy points after it - would otherwise be missed. Correctness is
+enforced by bucket_sessions_hourly()'s own `after` filter regardless; this is
+purely a fetch-window optimization to avoid re-scanning all of history."""
 
 
 def _floor_hour(value: datetime) -> datetime:
@@ -75,3 +107,91 @@ def bucket_sessions_hourly(
         running_sum += hourly_deltas[hour]
         statistics.append(StatisticData(start=hour, state=hourly_deltas[hour], sum=running_sum))
     return statistics
+
+
+class ZaptecStatisticsCoordinator(DataUpdateCoordinator[None]):
+    """Coordinator that imports one charger's archived sessions into HA statistics.
+
+    Runs independently of the live-state coordinators in coordinator.py: it
+    backdates hourly energy consumption from `/api/sessions/archived` into
+    HA's external-statistics store, fixing the Energy Dashboard's
+    misattributed-hour problem (upstream issue #300) caused by the live
+    Energy Meter sensor's polling cadence.
+    """
+
+    config_entry: ZaptecConfigEntry
+
+    def __init__(
+        self, hass: HomeAssistant, *, entry: ZaptecConfigEntry, charger: Charger
+    ) -> None:
+        """Initialize the statistics coordinator for one charger."""
+        self.charger = charger
+        self.statistic_id = f"{DOMAIN}:energy_{charger.id.replace('-', '')}"
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=f"{DOMAIN}-statistics-{charger.qual_id}",
+            update_interval=timedelta(seconds=ZAPTEC_STATISTICS_POLL_INTERVAL),
+        )
+
+    async def _async_update_data(self) -> None:
+        """Fetch new archived sessions and import them as external statistics."""
+        last_stats = await get_instance(self.hass).async_add_executor_job(
+            get_last_statistics,
+            self.hass,
+            1,
+            self.statistic_id,
+            True,  # noqa: FBT003
+            {"sum"},
+        )
+        if last_stats:
+            last = last_stats[self.statistic_id][0]
+            last_start = dt_util.utc_from_timestamp(last["start"])
+            running_sum = last["sum"] or 0.0
+        else:
+            last_start = dt_util.utcnow() - timedelta(days=ZAPTEC_STATISTICS_BACKFILL_DAYS)
+            running_sum = 0.0
+
+        sessions: list[dict[str, Any]] = []
+        cursor: str | None = None
+        try:
+            while True:
+                page = await self.charger.get_archived_sessions(
+                    from_time=last_start - RESUME_MARGIN,
+                    to_time=dt_util.utcnow(),
+                    cursor=cursor,
+                )
+                sessions.extend(page["Sessions"])
+                if not page.get("HasMore"):
+                    break
+                cursor = page["Cursor"]
+        except RequestError as err:
+            if err.error_code == HTTPStatus.FORBIDDEN:
+                # /api/sessions/archived requires the Owner role. Many Zaptec
+                # accounts won't have it on every charger - log once per poll
+                # rather than failing the coordinator every hour.
+                _LOGGER.warning(
+                    "No permission to read charge history for %s (requires Owner role), "
+                    "skipping energy statistics import",
+                    self.charger.qual_id,
+                )
+                return
+            raise UpdateFailed(err) from err
+        except ZaptecApiError as err:
+            raise UpdateFailed(err) from err
+
+        statistics = bucket_sessions_hourly(sessions, after=last_start, running_sum=running_sum)
+        if not statistics:
+            return
+
+        metadata = StatisticMetaData(
+            mean_type=StatisticMeanType.NONE,
+            has_sum=True,
+            name=f"{self.charger.name} Energy",
+            source=DOMAIN,
+            statistic_id=self.statistic_id,
+            unit_class=EnergyConverter.UNIT_CLASS,
+            unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        )
+        async_add_external_statistics(self.hass, metadata, statistics)

--- a/custom_components/zaptec/statistics.py
+++ b/custom_components/zaptec/statistics.py
@@ -1,0 +1,89 @@
+"""Import Zaptec charge history into Home Assistant's long-term statistics."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from homeassistant.components.recorder.models import StatisticData
+from homeassistant.util import dt as dt_util
+
+
+@dataclass
+class _StatisticDataWrapper:
+    """Wrapper for StatisticData that supports attribute access while maintaining type compatibility."""
+
+    start: datetime
+    state: float
+    sum: float
+
+
+def _floor_hour(value: datetime) -> datetime:
+    """Floor a datetime down to the start of its hour, in UTC."""
+    return dt_util.as_utc(value).replace(minute=0, second=0, microsecond=0)
+
+
+def bucket_sessions_hourly(
+    sessions: list[dict[str, Any]],
+    *,
+    after: datetime | None,
+    running_sum: float,
+) -> list[StatisticData]:
+    """Convert archived charge sessions into hourly external-statistics points.
+
+    Each session's `EnergyDetails` is a list of `{Timestamp, Energy}` points
+    where `Energy` is cumulative *within that session* (starts near 0). This
+    turns those into per-hour consumption deltas, bucketed by the hour
+    containing each point's timestamp. That's an approximation: a delta
+    between two points less than an hour apart can span an hour boundary
+    (Zaptec's default meter-reporting interval is 30 minutes), so a small
+    amount of energy can be attributed to the following hour rather than
+    split proportionally. This is still a large accuracy improvement over the
+    live sensor, which can lag by 1+ hour (upstream issue #300).
+
+    Sessions without `EnergyDetails` (e.g. pre-3.2 firmware) fall back to a
+    single point at `EndDateTime` using the session's total `Energy`. Sessions
+    marked `Voided` or `Aborted` are skipped entirely - per the API docs,
+    "voided sessions have no meaningful duration or energy" (they exist when
+    replaced by a corrected session, or when charging never actually started).
+
+    `sessions` must be sorted oldest-first (the archived-sessions API
+    guarantees this). Points at or before `after` are skipped, to avoid
+    double-counting data already imported by a previous run. `running_sum` is
+    the total energy (kWh) imported so far; the returned points chain onto it
+    so the statistic's `sum` keeps increasing monotonically.
+    """
+    hourly_deltas: dict[datetime, float] = defaultdict(float)
+
+    for session in sessions:
+        if session.get("Voided") or session.get("Aborted"):
+            continue
+
+        details = session.get("EnergyDetails") or []
+        if not details:
+            end = session.get("EndDateTime")
+            energy = session.get("Energy") or 0.0
+            if end and energy:
+                details = [{"Timestamp": end, "Energy": energy}]
+
+        prev_energy = 0.0
+        for point in details:
+            timestamp = dt_util.parse_datetime(point["Timestamp"])
+            if timestamp is None:
+                continue
+            energy = point["Energy"]
+            delta = energy - prev_energy
+            prev_energy = energy
+            if after is not None and timestamp <= after:
+                continue
+            hourly_deltas[_floor_hour(timestamp)] += delta
+
+    statistics: list[StatisticData] = []
+    for hour in sorted(hourly_deltas):
+        running_sum += hourly_deltas[hour]
+        statistics.append(
+            _StatisticDataWrapper(start=hour, state=hourly_deltas[hour], sum=running_sum)
+        )  # type: ignore[assignment]
+    return statistics

--- a/custom_components/zaptec/statistics.py
+++ b/custom_components/zaptec/statistics.py
@@ -63,14 +63,18 @@ def bucket_sessions_hourly(
     """Convert archived charge sessions into hourly external-statistics points.
 
     Each session's `energyDetails` is a list of `{timestamp, energy}` points
-    where `energy` is cumulative *within that session* (starts near 0). This
-    turns those into per-hour consumption deltas, bucketed by the hour
-    containing each point's timestamp. That's an approximation: a delta
-    between two points less than an hour apart can span an hour boundary
-    (Zaptec's default meter-reporting interval is 30 minutes), so a small
-    amount of energy can be attributed to the following hour rather than
-    split proportionally. This is still a large accuracy improvement over the
-    live sensor, which can lag by 1+ hour (upstream issue #300).
+    where `energy` is *already* the incremental delta since the previous
+    point, not a cumulative running total (confirmed live 2026-07-12 by
+    diffing a session's energyDetails against its own OCMF-signed
+    sessionSignature meter readings - the two matched exactly once the OCMF
+    cumulative values were themselves differenced). This turns those points
+    into per-hour consumption, bucketed by the hour containing each point's
+    timestamp. That's an approximation: a delta between two points less than
+    an hour apart can span an hour boundary (Zaptec's default
+    meter-reporting interval is 30 minutes), so a small amount of energy can
+    be attributed to the following hour rather than split proportionally.
+    This is still a large accuracy improvement over the live sensor, which
+    can lag by 1+ hour (upstream issue #300).
 
     Sessions without `energyDetails` (e.g. pre-3.2 firmware) fall back to a
     single point at `endDateTime` using the session's total `energy`. Sessions
@@ -105,14 +109,11 @@ def bucket_sessions_hourly(
             if end and energy:
                 details = [{"timestamp": end, "energy": energy}]
 
-        prev_energy = 0.0
         for point in details:
             timestamp = dt_util.parse_datetime(point["timestamp"])
             if timestamp is None:
                 continue
-            energy = point["energy"]
-            delta = energy - prev_energy
-            prev_energy = energy
+            delta = point["energy"]
             hour = _floor_hour(timestamp)
             if after is not None and hour <= after:
                 continue

--- a/custom_components/zaptec/zaptec/__init__.py
+++ b/custom_components/zaptec/zaptec/__init__.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from .api import Charger, Installation, Zaptec, ZaptecBase
-from .const import MISSING, Missing
+from .const import MISSING, RETRYABLE_HTTP_STATUSES, Missing
 from .exceptions import (
     AuthenticationError,
     RequestConnectionError,
     RequestDataError,
+    RequestError,
     RequestRetryError,
     RequestTimeoutError,
     ZaptecApiError,
@@ -18,6 +19,7 @@ from .zconst import ZCONST
 
 __all__ = [
     "MISSING",
+    "RETRYABLE_HTTP_STATUSES",
     "ZCONST",
     "AuthenticationError",
     "Charger",
@@ -26,6 +28,7 @@ __all__ = [
     "Redactor",
     "RequestConnectionError",
     "RequestDataError",
+    "RequestError",
     "RequestRetryError",
     "RequestTimeoutError",
     "Zaptec",

--- a/custom_components/zaptec/zaptec/api.py
+++ b/custom_components/zaptec/zaptec/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable, Iterator, Mapping
 from contextlib import aclosing
+from datetime import datetime
 from http import HTTPStatus
 import itertools
 import json
@@ -756,6 +757,39 @@ class Charger(ZaptecBase):
         _LOGGER.debug("Authorize charge")
         # NOTE: Undocumented API call
         return await self.zaptec.request(f"chargers/{self.id}/authorizecharge", method="post")
+
+    async def get_archived_sessions(
+        self,
+        *,
+        from_time: datetime,
+        to_time: datetime,
+        cursor: str | None = None,
+        page_size: int = 200,
+    ) -> TDict:
+        """Fetch one page of archived (completed) charge sessions for this charger.
+
+        Wraps `GET /api/sessions/archived`, filtered to this charger and
+        ordered oldest-first by the API. `from_time`/`to_time` are required by
+        the endpoint and filter by session *end* time (not start time), so a
+        long-running session only appears once it closes within the window.
+        Returns the page as-is (`Sessions`, `Cursor`, `HasMore`); the caller
+        follows `Cursor` while `HasMore` is true to page through the full
+        result set.
+
+        Requires the Owner role on this charger; raises `RequestError` with
+        `error_code == HTTPStatus.FORBIDDEN` otherwise (see
+        `ZaptecStatisticsCoordinator._async_update_data` in statistics.py for
+        how that's handled).
+        """
+        params: TDict = {
+            "ChargerId": self.id,
+            "PageSize": page_size,
+            "From": from_time.isoformat(),
+            "To": to_time.isoformat(),
+        }
+        if cursor is not None:
+            params["Cursor"] = cursor
+        return await self.zaptec.request("sessions/archived", params=params)
 
     async def set_permanent_cable_lock(self, lock: bool) -> Any:
         """Set the permanent cable lock on the charger."""

--- a/custom_components/zaptec/zaptec/api.py
+++ b/custom_components/zaptec/zaptec/api.py
@@ -1149,7 +1149,13 @@ class Zaptec(Mapping[str, ZaptecBase]):
                 )
 
     async def request(
-        self, url: str, *, method: str = "get", data: Any = None, base_url: str = API_URL
+        self,
+        url: str,
+        *,
+        method: str = "get",
+        data: Any = None,
+        params: dict[str, Any] | None = None,
+        base_url: str = API_URL,
     ) -> Any:
         """Make a request to the API."""
 
@@ -1163,6 +1169,8 @@ class Zaptec(Mapping[str, ZaptecBase]):
         }
         if data is not None:
             kwargs["json"] = data
+        if params is not None:
+            kwargs["params"] = params
 
         # Run the _request_worker() in a context manager that will close the
         # generator when the context is exited, ensuring the request and

--- a/custom_components/zaptec/zaptec/api.py
+++ b/custom_components/zaptec/zaptec/api.py
@@ -33,6 +33,7 @@ from .const import (
     DEFAULT_MAX_CURRENT,
     MAX_DEBUG_TEXT_LEN_ON_500,
     MISSING,
+    RETRYABLE_HTTP_STATUSES,
     TOKEN_URL,
     TRUTHY,
 )
@@ -945,6 +946,19 @@ class Zaptec(Mapping[str, ZaptecBase]):
         except Exception:
             _LOGGER.exception("Failed to log response (ignored exception)")
 
+    @staticmethod
+    def _parse_retry_after(value: str | None) -> float | None:
+        """Parse a Retry-After header value into seconds.
+
+        Only the integer delta-seconds form is supported; the HTTP-date form
+        returns None so the caller falls back to the exponential backoff."""
+        if not value:
+            return None
+        try:
+            return max(0.0, float(value))
+        except (TypeError, ValueError):
+            return None
+
     async def _request_worker(
         self, url: str, method: str = "get", retries: int = API_RETRIES, **kwargs
     ) -> AsyncGenerator[tuple[aiohttp.ClientResponse, TLogExc], None]:
@@ -958,6 +972,7 @@ class Zaptec(Mapping[str, ZaptecBase]):
         error: Exception | None = None
         delay: float = API_RETRY_INIT_DELAY
         sleep_delay: float = 0.0
+        retry_after: float | None = None
         start_time: float = time.perf_counter()
         iteration = 0
         for iteration in range(1, retries + 1):
@@ -998,6 +1013,22 @@ class Zaptec(Mapping[str, ZaptecBase]):
                             _LOGGER.error(str(exc), exc_info=exc)
                         return exc
 
+                    # Retry transient, infrastructure-level server errors
+                    # (429/502/503/504) regardless of method. These indicate
+                    # the request likely never reached the application, so a
+                    # retry is safe even for POST/PUT -- unlike 500, which is
+                    # handled per-method by the caller. On the final iteration
+                    # we fall through to yield so the caller raises the error.
+                    if response.status in RETRYABLE_HTTP_STATUSES and iteration < retries:
+                        if DEBUG_API_CALLS:
+                            _LOGGER.debug(
+                                "@@@  RETRYABLE STATUS %s, retrying (attempt %s)",
+                                response.status,
+                                iteration,
+                            )
+                        retry_after = self._parse_retry_after(response.headers.get("Retry-After"))
+                        continue  # Retry after backoff (or the Retry-After delay)
+
                     # Let the caller handle the response. If the caller
                     # calls __next__ on the generator the request will be
                     # retried.
@@ -1024,6 +1055,12 @@ class Zaptec(Mapping[str, ZaptecBase]):
                 # If the sleep time is negative, it means the request took
                 # longer than the calculated delay, so we don't need to sleep.
                 sleep_delay = delay - time.perf_counter() + start_time
+
+                # A Retry-After header from a transient response overrides the
+                # computed backoff for the next attempt.
+                if retry_after is not None:
+                    sleep_delay = min(retry_after, self._max_time)
+                    retry_after = None
 
         if isinstance(error, TimeoutError):
             raise RequestTimeoutError(

--- a/custom_components/zaptec/zaptec/const.py
+++ b/custom_components/zaptec/zaptec/const.py
@@ -18,6 +18,15 @@ CONST_URL = "https://api.zaptec.com/api/constants"
 API_RETRIES = 8  # Corresponds to median ~100 seconds of retries before giving up
 """Number of retries for API requests."""
 
+RETRYABLE_HTTP_STATUSES = frozenset({429, 502, 503, 504})
+"""Transient HTTP statuses that are retried with backoff regardless of method.
+
+Too Many Requests, Bad Gateway, Service Unavailable and Gateway Timeout are
+infrastructure-level "try again shortly" errors where the request typically
+never reached the application, so retrying is safe even for POST/PUT. This is
+distinct from 500 (Internal Server Error), which Zaptec returns in various
+application-level cases and is only retried for GET (see ``Zaptec.request``)."""
+
 API_RETRY_INIT_DELAY = 0.3
 """Initial delay for the first API retry."""
 

--- a/custom_components/zaptec/zaptec/validate.py
+++ b/custom_components/zaptec/zaptec/validate.py
@@ -101,14 +101,6 @@ class InstallationConnectionDetails(BaseModel):
     Topic: str
 
 
-class ArchivedSessionEnergyPoint(BaseModel):
-    """Pydantic model for a single cumulative-energy reading within an archived session."""
-
-    model_config = ConfigDict(extra="allow")
-    Timestamp: str
-    Energy: float
-
-
 class ArchivedSession(BaseModel):
     """Pydantic model for a single archived (completed) charge session."""
 
@@ -116,7 +108,6 @@ class ArchivedSession(BaseModel):
     Id: str
     ChargerId: str
     StartDateTime: str
-    EnergyDetails: list[ArchivedSessionEnergyPoint] | None = None
 
 
 class GetArchivedSessionsResponse(BaseModel):

--- a/custom_components/zaptec/zaptec/validate.py
+++ b/custom_components/zaptec/zaptec/validate.py
@@ -105,17 +105,17 @@ class ArchivedSession(BaseModel):
     """Pydantic model for a single archived (completed) charge session."""
 
     model_config = ConfigDict(extra="allow")
-    Id: str
-    ChargerId: str
-    StartDateTime: str
+    id: str
+    chargerId: str  # noqa: N815 (matches the API's actual camelCase field name)
+    startDateTime: str  # noqa: N815 (matches the API's actual camelCase field name)
 
 
 class GetArchivedSessionsResponse(BaseModel):
     """Pydantic model for a page of archived charge sessions."""
 
     model_config = ConfigDict(extra="allow")
-    Sessions: list[ArchivedSession]
-    HasMore: bool
+    sessions: list[ArchivedSession]
+    hasMore: bool  # noqa: N815 (matches the API's actual camelCase field name)
 
 
 CHARGER_FIRMWARES = TypeAdapter(list[ChargerFirmware])

--- a/custom_components/zaptec/zaptec/validate.py
+++ b/custom_components/zaptec/zaptec/validate.py
@@ -116,6 +116,7 @@ class ArchivedSession(BaseModel):
     Id: str
     ChargerId: str
     StartDateTime: str
+    EnergyDetails: list[ArchivedSessionEnergyPoint] | None = None
 
 
 class GetArchivedSessionsResponse(BaseModel):

--- a/custom_components/zaptec/zaptec/validate.py
+++ b/custom_components/zaptec/zaptec/validate.py
@@ -101,6 +101,31 @@ class InstallationConnectionDetails(BaseModel):
     Topic: str
 
 
+class ArchivedSessionEnergyPoint(BaseModel):
+    """Pydantic model for a single cumulative-energy reading within an archived session."""
+
+    model_config = ConfigDict(extra="allow")
+    Timestamp: str
+    Energy: float
+
+
+class ArchivedSession(BaseModel):
+    """Pydantic model for a single archived (completed) charge session."""
+
+    model_config = ConfigDict(extra="allow")
+    Id: str
+    ChargerId: str
+    StartDateTime: str
+
+
+class GetArchivedSessionsResponse(BaseModel):
+    """Pydantic model for a page of archived charge sessions."""
+
+    model_config = ConfigDict(extra="allow")
+    Sessions: list[ArchivedSession]
+    HasMore: bool
+
+
 CHARGER_FIRMWARES = TypeAdapter(list[ChargerFirmware])
 CHARGER_STATES = TypeAdapter(list[ChargerState])
 CONSTANTS = TypeAdapter(dict[str, Any])
@@ -124,6 +149,7 @@ URLS = {
     r"chargers/[0-9a-f\-]+/localSettings": None,
     r"chargers/[0-9a-f\-]+/update": None,
     r"chargerFirmware/installation/[0-9a-f\-]+": CHARGER_FIRMWARES,
+    "sessions/archived": GetArchivedSessionsResponse,
 }
 
 _URLS = [(k, re.compile(k), v) for k, v in URLS.items()]

--- a/docs/superpowers/plans/2026-07-11-energy-statistics-import.md
+++ b/docs/superpowers/plans/2026-07-11-energy-statistics-import.md
@@ -1,0 +1,1185 @@
+# Energy Statistics Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the Energy Dashboard's misattributed-hour problem (upstream [issue #300](https://github.com/custom-components/zaptec/issues/300), see also #162/#103) by backdating each charger's hourly energy consumption directly into Home Assistant's long-term statistics store, instead of relying on the live, polling-delayed `Energy Meter` sensor.
+
+**Architecture:** A new per-charger `ZaptecStatisticsCoordinator` (new file `custom_components/zaptec/statistics.py`) periodically fetches completed charge sessions from Zaptec's `GET /api/sessions/archived` endpoint (cursor-paginated, requires both a `From` and `To` bound filtering by session *end* time, includes a per-session `EnergyDetails` list of cumulative-energy/timestamp points), converts them into hourly deltas via a pure `bucket_sessions_hourly()` function, and writes them with `homeassistant.components.recorder.statistics.async_add_external_statistics()` under a stateless statistic id (`zaptec:energy_<chargerid>`) — mirroring the pattern used by HA core's Tibber integration (`homeassistant/components/tibber/coordinator.py::_insert_statistics`), which is the reference the issue itself points to. This entity never appears as a regular sensor; it only feeds the Energy Dashboard's statistics tables. Where to resume from is derived from the recorder's own `get_last_statistics()`, not separately-persisted state, so there's no new storage to keep in sync. The endpoint requires the **Owner role** on the queried charger, so the coordinator treats a 403 as a soft, logged skip rather than a hard failure — accounts using a non-Owner Zaptec user simply won't get this feature for that charger.
+
+**Tech Stack:** `homeassistant.components.recorder.statistics` (`async_add_external_statistics`, `get_last_statistics`), `homeassistant.helpers.update_coordinator.DataUpdateCoordinator`, `pydantic` (existing `validate.py` convention), pytest/pytest-asyncio/unittest.mock (existing conventions in `tests/`). No new dependencies.
+
+## Global Constraints
+
+- **Branch:** `feature/issue-300-energy-statistics`, created from `master` (which already contains `test/platform-entity-coverage`, merged via PR #5) — already checked out, do not create another branch.
+- Test command: `SKIP_ZAPTEC_API_TEST=true "C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests -q`
+- Lint gate: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m ruff format custom_components tests --diff` and `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m ruff check custom_components tests` must stay clean for every file this plan touches. The repo's ruff config uses `select = ["ALL"]`; run `ruff check` after writing each file and add `# noqa` comments to whatever it flags from actual output — don't pre-guess every one.
+- Never commit without explicit user approval (per repo CLAUDE.md) — stop before each commit step and wait for approval.
+- **Field casing — CONFIRMED via live test (2026-07-12):** every other Zaptec endpoint in this codebase returns PascalCase JSON (`Id`, `Name`, `DeviceType`...) even though `swagger.json` *declares* those same fields in camelCase — but `/api/sessions/archived` is the exception: a real account's response, captured via HA debug logging in the devcontainer, is genuinely **camelCase**, matching its swagger declaration for once: `{"sessions": [{"id": "b9b...", ...}], "cursor": null, "hasMore": false}` (confirmed top-level keys `sessions`/`cursor`/`hasMore` and the nested `id` key directly from a pydantic `ValidationError`'s `input_value`; the remaining nested field names — `chargerId`, `startDateTime`, `endDateTime`, `energy`, `energyDetails`, `timestamp`, `voided`, `aborted` — are inferred by extrapolation, since .NET's `System.Text.Json` camelCase policy is applied uniformly across a response, not selectively, but were not each individually observed in the captured log). All code and tests below use this confirmed camelCase shape. The request's *query parameters* (`ChargerId`, `PageSize`, `From`, `To`, `Cursor`) are unaffected and stay PascalCase as originally written — the live test's request succeeded (200 response), only the response-body validation failed, confirming query-parameter casing is a separate concern from JSON body casing for this API.
+- Do not touch the existing `ZaptecEnengySensor`/`Energy Meter` sensor (`sensor.py`) or the `Session total charge` sensor — they stay as-is; this plan adds a parallel, invisible statistics feed, it doesn't replace the live sensors.
+- Do not implement `/api/chargehistory` (the older, `PageIndex`-paginated endpoint) — `/api/sessions/archived` is the newer replacement with simpler cursor pagination, a larger page size (200 vs 100), and per-point cumulative energy always included (no `DetailLevel` flag needed). This isn't just a preference: Zaptec has an (undiscoverable-except-by-web-search, not linked from `llms.txt` or the docs SPA) deprecation notice at `docs.zaptec.com/page/archived-session-endpoints-and-legacy-session-deprecation-planned` stating legacy closed-session endpoints (including `chargehistory`) lose access to sessions older than 2 years on **2026-08-01** and are removed entirely on **2027-01-01** — `/api/sessions/archived` is explicitly named as the durable replacement.
+
+---
+
+## File Structure
+
+- **Modify: `custom_components/zaptec/zaptec/api.py`** — `Zaptec.request()` gains an optional `params` kwarg; `Charger` gains `get_archived_sessions()`.
+- **Modify: `custom_components/zaptec/zaptec/validate.py`** — new pydantic models for the `/api/sessions/archived` response.
+- **Modify: `custom_components/zaptec/const.py`** — `ZAPTEC_STATISTICS_POLL_INTERVAL`, `ZAPTEC_STATISTICS_BACKFILL_DAYS`.
+- **Create: `custom_components/zaptec/statistics.py`** — `bucket_sessions_hourly()` pure function and `ZaptecStatisticsCoordinator`.
+- **Modify: `custom_components/zaptec/manager.py`** — `ZaptecManager` gains a `statistics_coordinators: dict[str, ZaptecStatisticsCoordinator]` attribute.
+- **Modify: `custom_components/zaptec/__init__.py`** — create one `ZaptecStatisticsCoordinator` per tracked charger and run its first refresh during setup.
+- **Modify: `README.md`** — update the known-issues note (lines 58-63) once the feature ships.
+- **Modify: `tests/zaptec/test_api.py`** — tests for `params` passthrough and `get_archived_sessions()`.
+- **Create: `tests/test_statistics.py`** — tests for `bucket_sessions_hourly()` and `ZaptecStatisticsCoordinator`.
+
+---
+
+### Task 1: `Zaptec.request()` query-parameter support
+
+**Files:**
+- Modify: `custom_components/zaptec/zaptec/api.py:1151-1165`
+- Test: `tests/zaptec/test_api.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `Zaptec.request(url, *, method="get", data=None, params: dict[str, Any] | None = None, base_url=API_URL) -> Any` — Task 3's `Charger.get_archived_sessions()` calls this with `params=`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/zaptec/test_api.py` (near the other `test_request_*` tests, e.g. after `test_request_ok_returns_json`):
+
+```python
+@pytest.mark.asyncio
+async def test_request_passes_params_to_session() -> None:
+    """Query params are forwarded to the underlying session.request() call."""
+    payload = {"value": "answer"}
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.OK, json_data=payload)])
+    await zap.request("unregistered/url", params={"Foo": "bar", "PageSize": 200})
+    assert session.calls[0][2]["params"] == {"Foo": "bar", "PageSize": 200}
+
+
+@pytest.mark.asyncio
+async def test_request_omits_params_when_not_given() -> None:
+    """No params kwarg is passed to session.request() when none are given."""
+    payload = {"value": "answer"}
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.OK, json_data=payload)])
+    await zap.request("unregistered/url")
+    assert "params" not in session.calls[0][2]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests/zaptec/test_api.py -k params -v`
+Expected: FAIL — `TypeError: Zaptec.request() got an unexpected keyword argument 'params'`
+
+- [ ] **Step 3: Implement `params` support**
+
+In `custom_components/zaptec/zaptec/api.py`, change:
+
+```python
+    async def request(
+        self, url: str, *, method: str = "get", data: Any = None, base_url: str = API_URL
+    ) -> Any:
+        """Make a request to the API."""
+
+        full_url = base_url + url
+        kwargs = {
+            "timeout": self._timeout,
+            "headers": {
+                "Authorization": f"Bearer {self._access_token}",
+                "Accept": "application/json",
+            },
+        }
+        if data is not None:
+            kwargs["json"] = data
+```
+
+to:
+
+```python
+    async def request(
+        self,
+        url: str,
+        *,
+        method: str = "get",
+        data: Any = None,
+        params: dict[str, Any] | None = None,
+        base_url: str = API_URL,
+    ) -> Any:
+        """Make a request to the API."""
+
+        full_url = base_url + url
+        kwargs = {
+            "timeout": self._timeout,
+            "headers": {
+                "Authorization": f"Bearer {self._access_token}",
+                "Accept": "application/json",
+            },
+        }
+        if data is not None:
+            kwargs["json"] = data
+        if params is not None:
+            kwargs["params"] = params
+```
+
+`aiohttp.ClientSession.request()` (invoked via `self._client.request(method=method, url=url, **kwargs)` inside `_request_worker`) natively accepts a `params` kwarg and appends it as a query string, so no other change to `_request_worker`/`request()` is needed. `validate(json_result, url=url)` continues to receive the path-only `url` (no query string), so existing `URLS` regex patterns in `validate.py` are unaffected.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests/zaptec/test_api.py -k params -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Run full test suite and lint**
+
+Run: `SKIP_ZAPTEC_API_TEST=true "C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests -q`
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m ruff check custom_components/zaptec/zaptec/api.py tests/zaptec/test_api.py`
+Expected: both clean (fix any `noqa`-worthy findings from actual ruff output)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/zaptec/zaptec/api.py tests/zaptec/test_api.py
+git commit -m "feat: support query params in Zaptec.request()"
+```
+
+---
+
+### Task 2: Validation models for `/api/sessions/archived`
+
+**Files:**
+- Modify: `custom_components/zaptec/zaptec/validate.py:104-127`
+
+**Interfaces:**
+- Consumes: nothing new (existing `BaseModel`, `ConfigDict`, `TypeAdapter` imports).
+- Produces: registers `"sessions/archived"` in the `URLS` validation map (Task 3's `get_archived_sessions()` calls `zaptec.request("sessions/archived", ...)`, which routes through this map). No new names are exported for other tasks to consume — validation failures only log, per existing `validate()` behavior.
+
+- [ ] **Step 1: Add the models**
+
+In `custom_components/zaptec/zaptec/validate.py`, insert before the `CHARGER_FIRMWARES = TypeAdapter(...)` line (currently line 104):
+
+```python
+class ArchivedSession(BaseModel):
+    """Pydantic model for a single archived (completed) charge session."""
+
+    model_config = ConfigDict(extra="allow")
+    id: str
+    chargerId: str
+    startDateTime: str
+
+
+class GetArchivedSessionsResponse(BaseModel):
+    """Pydantic model for a page of archived charge sessions."""
+
+    model_config = ConfigDict(extra="allow")
+    sessions: list[ArchivedSession]
+    hasMore: bool
+```
+
+Then add to the `URLS` dict (after the `chargerFirmware/installation/[0-9a-f\-]+` entry, currently line 126):
+
+```python
+    "sessions/archived": GetArchivedSessionsResponse,
+```
+
+**Update (confirmed live, 2026-07-12):** unlike every other Zaptec endpoint in this codebase, `/api/sessions/archived` genuinely returns **camelCase** JSON — confirmed via a real account's response captured in HA debug logs (`{"sessions": [{"id": "b9b...", ...}], "cursor": null, "hasMore": false}`). Field names above (`id`/`chargerId`/`startDateTime`/`sessions`/`hasMore`) reflect this. `ArchivedSession` still intentionally omits `endDateTime`/`energy`/`energyDetails` as *required* fields (unlike `id`/`chargerId`/`startDateTime`) — `extra="allow"` passes them through unchecked, and `statistics.py` (Task 4) reads those via plain `dict.get()`, not through this model. Do **not** add a separate `ArchivedSessionEnergyPoint` model to type `energyDetails` — an earlier execution of this plan tried exactly that and a reviewer caught that a strict nested model can raise `ValidationError` for the *entire page* if a shape assumption is ever wrong; leave `energyDetails` unvalidated under `extra="allow"`.
+
+- [ ] **Step 2: Run lint**
+
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m ruff check custom_components/zaptec/zaptec/validate.py`
+Expected: clean
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `SKIP_ZAPTEC_API_TEST=true "C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests -q`
+Expected: PASS (no behavior change yet, nothing calls this URL until Task 3)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add custom_components/zaptec/zaptec/validate.py
+git commit -m "feat: add validation model for sessions/archived endpoint"
+```
+
+---
+
+### Task 3: `Charger.get_archived_sessions()`
+
+**Files:**
+- Modify: `custom_components/zaptec/zaptec/api.py:758` (insert after `authorize_charge`, before `set_permanent_cable_lock`)
+- Modify: `custom_components/zaptec/zaptec/api.py:3` (add `datetime` import if not already present — it isn't; `api.py` currently has no `datetime` import)
+- Test: `tests/zaptec/test_api.py`
+
+**Interfaces:**
+- Consumes: `Zaptec.request(url, *, params=...)` from Task 1.
+- Produces: `Charger.get_archived_sessions(self, *, from_time: datetime, to_time: datetime, cursor: str | None = None, page_size: int = 200) -> TDict` returning the raw page dict (`{"sessions": [...], "cursor": ..., "hasMore": ...}` — confirmed camelCase, see Global Constraints) — consumed by Task 5's `ZaptecStatisticsCoordinator._async_update_data()`.
+
+Per the endpoint's own docs (`https://docs.zaptec.com/reference/api_sessions_archived_get.md`, confirmed directly, not just inferred from swagger): **`From` and `To` are both required** ("Inclusive lower bound for session end time" / "Exclusive upper bound for session end time. Required, must be after `from`") — they filter by session **end** time, not start time. The endpoint also **requires the Owner role** on the queried charger/installation, so accounts using a non-Owner Zaptec user will get a 403 on every call — Task 5 must treat that as a soft failure (log + skip), not a hard `UpdateFailed`, or every non-Owner user's log will fill with coordinator errors every poll.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/zaptec/test_api.py`:
+
+```python
+from datetime import datetime, timezone
+
+
+@pytest.mark.asyncio
+async def test_get_archived_sessions_builds_params() -> None:
+    """get_archived_sessions() sends ChargerId, PageSize, From, To and Cursor as query params."""
+    payload = {"sessions": [], "cursor": None, "hasMore": False}
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.OK, json_data=payload)])
+    charger = Charger({"Id": "charger-1"}, zap, installation=None)
+
+    result = await charger.get_archived_sessions(
+        from_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        to_time=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        cursor="abc",
+    )
+
+    assert result == payload
+    method, url, kwargs = session.calls[0]
+    assert method == "get"
+    assert url == "https://api.zaptec.com/api/sessions/archived"
+    assert kwargs["params"] == {
+        "ChargerId": "charger-1",
+        "PageSize": 200,
+        "From": "2026-01-01T00:00:00+00:00",
+        "To": "2026-01-02T00:00:00+00:00",
+        "Cursor": "abc",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_archived_sessions_omits_cursor_when_not_given() -> None:
+    """cursor is omitted from params when not given; From/To are always sent."""
+    payload = {"sessions": [], "cursor": None, "hasMore": False}
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.OK, json_data=payload)])
+    charger = Charger({"Id": "charger-1"}, zap, installation=None)
+
+    await charger.get_archived_sessions(
+        from_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        to_time=datetime(2026, 1, 2, tzinfo=timezone.utc),
+    )
+
+    assert session.calls[0][2]["params"] == {
+        "ChargerId": "charger-1",
+        "PageSize": 200,
+        "From": "2026-01-01T00:00:00+00:00",
+        "To": "2026-01-02T00:00:00+00:00",
+    }
+```
+
+Check what `API_URL` resolves to before trusting the exact URL assertion above:
+
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -c "from custom_components.zaptec.zaptec.const import API_URL; print(API_URL)"`
+
+Adjust the `url ==` assertion in the test to match whatever this prints (it is expected to be `https://api.zaptec.com/api/`, giving `https://api.zaptec.com/api/sessions/archived` — fix the literal if the actual value differs).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests/zaptec/test_api.py -k archived_sessions -v`
+Expected: FAIL — `AttributeError: 'Charger' object has no attribute 'get_archived_sessions'`
+
+- [ ] **Step 3: Implement**
+
+Add `from datetime import datetime` to the imports at the top of `custom_components/zaptec/zaptec/api.py` (alongside the existing `import time` etc., around line 14).
+
+Insert into the `Charger` class, after `authorize_charge()` (ends at line 758) and before `set_permanent_cable_lock()`:
+
+```python
+    async def get_archived_sessions(
+        self,
+        *,
+        from_time: datetime,
+        to_time: datetime,
+        cursor: str | None = None,
+        page_size: int = 200,
+    ) -> TDict:
+        """Fetch one page of archived (completed) charge sessions for this charger.
+
+        Wraps `GET /api/sessions/archived`, filtered to this charger and
+        ordered oldest-first by the API. `from_time`/`to_time` are required by
+        the endpoint and filter by session *end* time (not start time), so a
+        long-running session only appears once it closes within the window.
+        Returns the page as-is (`Sessions`, `Cursor`, `HasMore`); the caller
+        follows `Cursor` while `HasMore` is true to page through the full
+        result set.
+
+        Requires the Owner role on this charger; raises `RequestError` with
+        `error_code == HTTPStatus.FORBIDDEN` otherwise (see
+        `ZaptecStatisticsCoordinator._async_update_data` in statistics.py for
+        how that's handled).
+        """
+        params: TDict = {
+            "ChargerId": self.id,
+            "PageSize": page_size,
+            "From": from_time.isoformat(),
+            "To": to_time.isoformat(),
+        }
+        if cursor is not None:
+            params["Cursor"] = cursor
+        return await self.zaptec.request("sessions/archived", params=params)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests/zaptec/test_api.py -k archived_sessions -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Add the live-credential smoke test (manual, run once against a real account)**
+
+Add to `tests/zaptec/test_api.py`, near the existing `test_api` function:
+
+```python
+@pytest.mark.asyncio
+async def test_get_archived_sessions_live(zaptec_username: str, zaptec_password: str) -> None:
+    """Smoke-test the real field casing of /api/sessions/archived.
+
+    Skipped in CI and when SKIP_ZAPTEC_API_TEST=true, same as test_api above.
+    Run this manually against a real account at least once: swagger.json
+    *declares* this endpoint's fields in camelCase, but every other Zaptec
+    endpoint actually returns PascalCase despite the same swagger mismatch
+    (see validate.py's Charger/Installation models vs swagger's
+    ChargerListModel). If this test fails after fixing obvious typos, the
+    casing assumption in validate.py/statistics.py needs correcting. It will
+    also surface a 403 here if the test account lacks the Owner role this
+    endpoint requires - that's expected for non-Owner accounts, not a bug.
+    """
+    from datetime import timedelta
+
+    from homeassistant.util import dt as dt_util
+
+    async with Zaptec(zaptec_username, zaptec_password) as zaptec:
+        await zaptec.login()
+        await zaptec.build()
+        chargers = list(zaptec.chargers)
+        if not chargers:
+            pytest.skip("Account has no chargers to test against")
+
+        now = dt_util.utcnow()
+        page = await chargers[0].get_archived_sessions(
+            from_time=now - timedelta(days=730), to_time=now, page_size=5
+        )
+        assert "sessions" in page
+        assert "hasMore" in page
+        if page["sessions"]:
+            session = page["sessions"][0]
+            assert "id" in session
+            assert "startDateTime" in session
+            _LOGGER.info("Sample archived session: %s", session)
+```
+
+Run once with real credentials: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests/zaptec/test_api.py -k live -v -s` (requires `ZAPTEC_USERNAME`/`ZAPTEC_PASSWORD` env vars). Read the logged sample session and confirm the field names match what Task 2/4/5 assume before proceeding — this is the one step in this plan that cannot be verified automatically in this dev environment (see CLAUDE.md's note on the aiohttp async DNS-resolver gap, which affects live calls here even with credentials — this test may need to be run in the devcontainer instead).
+
+- [ ] **Step 6: Run full test suite and lint**
+
+Run: `SKIP_ZAPTEC_API_TEST=true "C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests -q`
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m ruff check custom_components/zaptec/zaptec/api.py tests/zaptec/test_api.py`
+Expected: both clean
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add custom_components/zaptec/zaptec/api.py tests/zaptec/test_api.py
+git commit -m "feat: add Charger.get_archived_sessions()"
+```
+
+---
+
+### Task 4: `bucket_sessions_hourly()` pure function
+
+**Files:**
+- Create: `custom_components/zaptec/statistics.py`
+- Test: `tests/test_statistics.py`
+
+**Interfaces:**
+- Consumes: `homeassistant.components.recorder.models.StatisticData` (HA core type, no local import needed beyond that).
+- Produces: `bucket_sessions_hourly(sessions: list[dict[str, Any]], *, after: datetime | None, running_sum: float) -> list[StatisticData]` — consumed by Task 5's `ZaptecStatisticsCoordinator._async_update_data()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_statistics.py`:
+
+```python
+"""Tests for statistics.py."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from custom_components.zaptec.statistics import bucket_sessions_hourly
+
+
+def _session(
+    session_id: str, points: list[tuple[str, float]], *, end: str | None = None, energy: float = 0.0
+) -> dict:
+    """Build a raw archived-session dict with the given energyDetails points."""
+    return {
+        "id": session_id,
+        "endDateTime": end,
+        "energy": energy,
+        "energyDetails": [{"timestamp": ts, "energy": e} for ts, e in points],
+    }
+
+
+def test_single_session_within_one_hour() -> None:
+    """A session with all points inside one hour produces a single bucket."""
+    session = _session("s1", [("2026-01-01T10:10:00+00:00", 1.0), ("2026-01-01T10:40:00+00:00", 2.5)])
+
+    result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
+
+    assert len(result) == 1
+    assert result[0]["start"] == datetime(2026, 1, 1, 10, tzinfo=timezone.utc)
+    assert result[0]["state"] == 2.5
+    assert result[0]["sum"] == 2.5
+
+
+def test_session_spanning_two_hours_creates_two_buckets() -> None:
+    """Points either side of an hour boundary land in different buckets."""
+    session = _session(
+        "s1",
+        [
+            ("2026-01-01T10:50:00+00:00", 1.0),
+            ("2026-01-01T11:20:00+00:00", 1.6),
+        ],
+    )
+
+    result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
+
+    assert [r["start"] for r in result] == [
+        datetime(2026, 1, 1, 10, tzinfo=timezone.utc),
+        datetime(2026, 1, 1, 11, tzinfo=timezone.utc),
+    ]
+    assert result[0]["state"] == 1.0
+    assert result[0]["sum"] == 1.0
+    assert result[1]["state"] == 0.6000000000000001  # noqa: PLR2004
+    assert result[1]["sum"] == 1.6
+
+
+def test_after_cutoff_excludes_already_imported_points() -> None:
+    """Points at or before `after` are skipped, avoiding double-counting."""
+    session = _session(
+        "s1",
+        [
+            ("2026-01-01T10:10:00+00:00", 1.0),
+            ("2026-01-01T11:10:00+00:00", 2.0),
+        ],
+    )
+    cutoff = datetime(2026, 1, 1, 10, 30, tzinfo=timezone.utc)
+
+    result = bucket_sessions_hourly([session], after=cutoff, running_sum=5.0)
+
+    assert len(result) == 1
+    assert result[0]["start"] == datetime(2026, 1, 1, 11, tzinfo=timezone.utc)
+    assert result[0]["state"] == 1.0
+    assert result[0]["sum"] == 6.0
+
+
+def test_session_without_energy_details_falls_back_to_total() -> None:
+    """A legacy session with no energyDetails uses its total energy at endDateTime."""
+    session = {
+        "id": "s1",
+        "endDateTime": "2026-01-01T10:45:00+00:00",
+        "energy": 3.0,
+        "energyDetails": [],
+    }
+
+    result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
+
+    assert len(result) == 1
+    assert result[0]["start"] == datetime(2026, 1, 1, 10, tzinfo=timezone.utc)
+    assert result[0]["state"] == 3.0
+
+
+def test_running_sum_carries_across_sessions() -> None:
+    """The running sum accumulates across multiple sessions, oldest first."""
+    session1 = _session("s1", [("2026-01-01T10:10:00+00:00", 1.0)])
+    session2 = _session("s2", [("2026-01-01T12:10:00+00:00", 2.0)])
+
+    result = bucket_sessions_hourly([session1, session2], after=None, running_sum=10.0)
+
+    assert [r["sum"] for r in result] == [11.0, 13.0]
+
+
+def test_voided_and_aborted_sessions_are_skipped() -> None:
+    """Voided/aborted sessions have no meaningful energy and must not be counted."""
+    voided = _session("s1", [("2026-01-01T10:10:00+00:00", 1.0)])
+    voided["voided"] = True
+    aborted = _session("s2", [("2026-01-01T11:10:00+00:00", 2.0)])
+    aborted["aborted"] = True
+    real = _session("s3", [("2026-01-01T12:10:00+00:00", 3.0)])
+
+    result = bucket_sessions_hourly([voided, aborted, real], after=None, running_sum=0.0)
+
+    assert len(result) == 1
+    assert result[0]["start"] == datetime(2026, 1, 1, 12, tzinfo=timezone.utc)
+    assert result[0]["state"] == 3.0
+```
+
+Note: `StatisticData` (`homeassistant.components.recorder.models`) is a `TypedDict`, i.e. a plain `dict` at runtime — access fields with `result[0]["start"]`, not `result[0].start`. The construction code in Step 3 below already gets this right (`StatisticData(start=hour, state=..., sum=...)` is a valid `TypedDict` constructor call that returns a real dict); only the test assertions needed the dict-key form. Do not introduce a wrapper dataclass to support attribute access — that would return an object `async_add_external_statistics()` (Task 5) doesn't actually expect.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests/test_statistics.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'custom_components.zaptec.statistics'`
+
+- [ ] **Step 3: Implement**
+
+Create `custom_components/zaptec/statistics.py`:
+
+```python
+"""Import Zaptec charge history into Home Assistant's long-term statistics."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+
+from homeassistant.components.recorder.models import StatisticData
+from homeassistant.util import dt as dt_util
+
+
+def _floor_hour(value: datetime) -> datetime:
+    """Floor a datetime down to the start of its hour, in UTC."""
+    return dt_util.as_utc(value).replace(minute=0, second=0, microsecond=0)
+
+
+def bucket_sessions_hourly(
+    sessions: list[dict[str, Any]],
+    *,
+    after: datetime | None,
+    running_sum: float,
+) -> list[StatisticData]:
+    """Convert archived charge sessions into hourly external-statistics points.
+
+    Each session's `energyDetails` is a list of `{timestamp, energy}` points
+    (camelCase - confirmed live, see Global Constraints) where `energy` is
+    cumulative *within that session* (starts near 0). This turns those into
+    per-hour consumption deltas, bucketed by the hour containing each point's
+    timestamp. That's an approximation: a delta between two points less than
+    an hour apart can span an hour boundary (Zaptec's default meter-reporting
+    interval is 30 minutes), so a small amount of energy can be attributed to
+    the following hour rather than split proportionally. This is still a
+    large accuracy improvement over the live sensor, which can lag by 1+ hour
+    (upstream issue #300).
+
+    Sessions without `energyDetails` (e.g. pre-3.2 firmware) fall back to a
+    single point at `endDateTime` using the session's total `energy`. Sessions
+    marked `voided` or `aborted` are skipped entirely - per the API docs,
+    "voided sessions have no meaningful duration or energy" (they exist when
+    replaced by a corrected session, or when charging never actually started).
+
+    `sessions` must be sorted oldest-first (the archived-sessions API
+    guarantees this). `after` is the start of the last hour already imported
+    by a previous run (its `sum` already reflects that whole hour) - so any
+    point whose *floored hour* is at or before `after` is skipped, not just
+    points with a raw timestamp at or before `after`. Skipping by raw
+    timestamp would under-skip: a point at, say, 11:10 has a later raw
+    timestamp than `after=11:00` and would slip through, getting re-added to
+    an hour whose total was already stored - corrupting the external
+    statistic with compounding phantom energy on every subsequent poll,
+    since `/sessions/archived`'s `From` filter keeps returning the same
+    session until a newer one supersedes it as the resume point. `running_sum`
+    is the total energy (kWh) imported so far; the returned points chain onto
+    it so the statistic's `sum` keeps increasing monotonically.
+    """
+    hourly_deltas: dict[datetime, float] = defaultdict(float)
+
+    for session in sessions:
+        if session.get("voided") or session.get("aborted"):
+            continue
+
+        details = session.get("energyDetails") or []
+        if not details:
+            end = session.get("endDateTime")
+            energy = session.get("energy") or 0.0
+            if end and energy:
+                details = [{"timestamp": end, "energy": energy}]
+
+        prev_energy = 0.0
+        for point in details:
+            timestamp = dt_util.parse_datetime(point["timestamp"])
+            if timestamp is None:
+                continue
+            energy = point["energy"]
+            delta = energy - prev_energy
+            prev_energy = energy
+            hour = _floor_hour(timestamp)
+            if after is not None and hour <= after:
+                continue
+            hourly_deltas[hour] += delta
+
+    statistics: list[StatisticData] = []
+    for hour in sorted(hourly_deltas):
+        running_sum += hourly_deltas[hour]
+        statistics.append(StatisticData(start=hour, state=hourly_deltas[hour], sum=running_sum))
+    return statistics
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests/test_statistics.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Run full test suite and lint**
+
+Run: `SKIP_ZAPTEC_API_TEST=true "C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests -q`
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m ruff check custom_components/zaptec/statistics.py tests/test_statistics.py`
+Expected: both clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/zaptec/statistics.py tests/test_statistics.py
+git commit -m "feat: add hourly bucketing for archived charge sessions"
+```
+
+---
+
+### Task 5: `ZaptecStatisticsCoordinator`
+
+**Files:**
+- Modify: `custom_components/zaptec/const.py` (append new constants)
+- Modify: `custom_components/zaptec/statistics.py` (add the coordinator class)
+- Test: `tests/test_statistics.py`
+
+**Interfaces:**
+- Consumes: `bucket_sessions_hourly()` (Task 4), `Charger.get_archived_sessions()` (Task 3), `Charger.id`/`.name`/`.qual_id` (existing `ZaptecBase` properties).
+- Produces: `ZaptecStatisticsCoordinator(hass, *, entry: ZaptecConfigEntry, charger: Charger)`, a `DataUpdateCoordinator[None]` subclass with a public `.statistic_id: str` attribute — consumed by Task 6's `__init__.py`/`manager.py` wiring.
+
+- [ ] **Step 1: Add constants**
+
+Append to `custom_components/zaptec/const.py`:
+
+```python
+ZAPTEC_STATISTICS_POLL_INTERVAL = 60 * 60
+"""Interval in seconds between imports of archived charge sessions into HA statistics."""
+
+ZAPTEC_STATISTICS_BACKFILL_DAYS = 730
+"""How far back (in days) to backfill energy statistics on first import."""
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `tests/test_statistics.py`:
+
+```python
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.zaptec.statistics import ZaptecStatisticsCoordinator
+from custom_components.zaptec.zaptec import Charger
+
+
+def _make_charger(charger_id: str = "charger-1") -> MagicMock:
+    """A fake Charger exposing only what the coordinator touches."""
+    charger = MagicMock(spec=Charger)
+    charger.id = charger_id
+    charger.name = "My Charger"
+    charger.qual_id = f"Charger[{charger_id}]"
+    return charger
+
+
+@pytest.mark.asyncio
+async def test_statistic_id_derived_from_charger_id(hass: MagicMock, config_entry: Any) -> None:
+    """The statistic_id is stable and derived from the charger's id."""
+    charger = _make_charger("abc-123")
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+    assert coordinator.statistic_id == "zaptec:energy_abc123"
+
+
+@pytest.mark.asyncio
+async def test_first_run_backfills_from_zero_sum(hass: MagicMock, config_entry: Any) -> None:
+    """With no prior statistics, the coordinator starts from sum=0 and pages through results."""
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        return_value={
+            "sessions": [
+                {
+                    "id": "s1",
+                    "energyDetails": [{"timestamp": "2026-01-01T10:10:00+00:00", "energy": 2.0}],
+                }
+            ],
+            "cursor": None,
+            "hasMore": False,
+        }
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch("custom_components.zaptec.statistics.get_last_statistics", return_value={}),
+        patch("custom_components.zaptec.statistics.async_add_external_statistics") as mock_add,
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        await coordinator._async_update_data()  # noqa: SLF001
+
+    assert mock_add.call_count == 1
+    _hass_arg, metadata, statistics = mock_add.call_args[0]
+    # StatisticMetaData and StatisticData are both TypedDicts (plain dicts at
+    # runtime) - use dict-key access, not attribute access.
+    assert metadata["statistic_id"] == "zaptec:energy_charger1"
+    assert metadata["name"] == "My Charger Energy"
+    assert len(statistics) == 1
+    assert statistics[0]["sum"] == 2.0
+    charger.get_archived_sessions.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_new_sessions_does_not_call_add_statistics(
+    hass: MagicMock, config_entry: Any
+) -> None:
+    """If there's nothing new to import, async_add_external_statistics is not called."""
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        return_value={"sessions": [], "cursor": None, "hasMore": False}
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch("custom_components.zaptec.statistics.get_last_statistics", return_value={}),
+        patch("custom_components.zaptec.statistics.async_add_external_statistics") as mock_add,
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        await coordinator._async_update_data()  # noqa: SLF001
+
+    mock_add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resumes_from_last_statistics(hass: MagicMock, config_entry: Any) -> None:
+    """A prior statistics entry sets the resume point and running sum."""
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        return_value={"sessions": [], "cursor": None, "hasMore": False}
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+    last_start = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch(
+            "custom_components.zaptec.statistics.get_last_statistics",
+            return_value={
+                coordinator.statistic_id: [
+                    {"start": last_start.timestamp(), "sum": 42.0}
+                ]
+            },
+        ),
+        patch("custom_components.zaptec.statistics.async_add_external_statistics"),
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        await coordinator._async_update_data()  # noqa: SLF001
+
+    call_kwargs = charger.get_archived_sessions.call_args.kwargs
+    assert call_kwargs["from_time"] == last_start - timedelta(hours=26)
+    # to_time is "now" at call time - assert it's recent rather than exact.
+    assert (dt_util.utcnow() - call_kwargs["to_time"]) < timedelta(seconds=5)
+
+
+@pytest.mark.asyncio
+async def test_forbidden_error_is_logged_not_raised(hass: MagicMock, config_entry: Any) -> None:
+    """A 403 (non-Owner account) is logged and skipped, not raised as UpdateFailed.
+
+    /api/sessions/archived requires the Owner role - many Zaptec accounts
+    won't have it on every charger, and that shouldn't repeatedly fail the
+    coordinator/spam the log with UpdateFailed errors on every poll.
+    """
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        side_effect=RequestError("forbidden", HTTPStatus.FORBIDDEN)
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch("custom_components.zaptec.statistics.get_last_statistics", return_value={}),
+        patch("custom_components.zaptec.statistics.async_add_external_statistics") as mock_add,
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        await coordinator._async_update_data()  # noqa: SLF001
+
+    mock_add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_other_request_errors_raise_update_failed(hass: MagicMock, config_entry: Any) -> None:
+    """A non-403 RequestError still raises UpdateFailed, so HA surfaces it normally."""
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        side_effect=RequestError("server error", HTTPStatus.INTERNAL_SERVER_ERROR)
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch("custom_components.zaptec.statistics.get_last_statistics", return_value={}),
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()  # noqa: SLF001
+```
+
+Add these imports to the test file: `from homeassistant.helpers.update_coordinator import UpdateFailed`, `from homeassistant.util import dt as dt_util`, `from http import HTTPStatus`, and `from custom_components.zaptec.zaptec.exceptions import RequestError`.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests/test_statistics.py -k Coordinator -v`
+Expected: FAIL — `ImportError: cannot import name 'ZaptecStatisticsCoordinator'`
+
+- [ ] **Step 4: Implement the coordinator**
+
+`custom_components/zaptec/statistics.py` currently starts with (from Task 4):
+
+```python
+"""Import Zaptec charge history into Home Assistant's long-term statistics."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+
+from homeassistant.components.recorder.models import StatisticData
+from homeassistant.util import dt as dt_util
+
+
+def _floor_hour(value: datetime) -> datetime:
+```
+
+Replace that header (everything from `from __future__ import annotations` down to, but not including, `def _floor_hour`) with:
+
+```python
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta
+from http import HTTPStatus
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.recorder import get_instance
+from homeassistant.components.recorder.models import (
+    StatisticData,
+    StatisticMeanType,
+    StatisticMetaData,
+)
+from homeassistant.components.recorder.statistics import (
+    async_add_external_statistics,
+    get_last_statistics,
+)
+from homeassistant.const import UnitOfEnergy
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_conversion import EnergyConverter
+
+from .const import DOMAIN, ZAPTEC_STATISTICS_BACKFILL_DAYS, ZAPTEC_STATISTICS_POLL_INTERVAL
+from .zaptec import Charger, RequestError, ZaptecApiError
+
+if TYPE_CHECKING:
+    from .manager import ZaptecConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+RESUME_MARGIN = timedelta(hours=26)
+"""Extra lookback window (beyond the last imported hour) when querying the API.
+
+/api/sessions/archived filters by session *end* time, not start time,
+so a session that closes slightly before our nominal `From` cutoff - but
+still has energy points after it - would otherwise be missed. Correctness is
+enforced by bucket_sessions_hourly()'s own `after` filter regardless; this is
+purely a fetch-window optimization to avoid re-scanning all of history."""
+
+
+def _floor_hour(value: datetime) -> datetime:
+```
+
+`_floor_hour()` and `bucket_sessions_hourly()` themselves (the rest of the file from Task 4) are unchanged — this only replaces the module header above them. Then append the new class at the end of the file, after `bucket_sessions_hourly()`:
+
+```python
+class ZaptecStatisticsCoordinator(DataUpdateCoordinator[None]):
+    """Coordinator that imports one charger's archived sessions into HA statistics.
+
+    Runs independently of the live-state coordinators in coordinator.py: it
+    backdates hourly energy consumption from `/api/sessions/archived` into
+    HA's external-statistics store, fixing the Energy Dashboard's
+    misattributed-hour problem (upstream issue #300) caused by the live
+    Energy Meter sensor's polling cadence.
+    """
+
+    config_entry: ZaptecConfigEntry
+
+    def __init__(
+        self, hass: HomeAssistant, *, entry: ZaptecConfigEntry, charger: Charger
+    ) -> None:
+        """Initialize the statistics coordinator for one charger."""
+        self.charger = charger
+        self.statistic_id = f"{DOMAIN}:energy_{charger.id.replace('-', '')}"
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=f"{DOMAIN}-statistics-{charger.qual_id}",
+            update_interval=timedelta(seconds=ZAPTEC_STATISTICS_POLL_INTERVAL),
+        )
+
+    async def _async_update_data(self) -> None:
+        """Fetch new archived sessions and import them as external statistics."""
+        last_stats = await get_instance(self.hass).async_add_executor_job(
+            get_last_statistics, self.hass, 1, self.statistic_id, True, {"sum"}
+        )
+        if last_stats:
+            last = last_stats[self.statistic_id][0]
+            last_start = dt_util.utc_from_timestamp(last["start"])
+            running_sum = last["sum"] or 0.0
+        else:
+            last_start = dt_util.utcnow() - timedelta(days=ZAPTEC_STATISTICS_BACKFILL_DAYS)
+            running_sum = 0.0
+
+        sessions: list[dict[str, Any]] = []
+        cursor: str | None = None
+        try:
+            while True:
+                page = await self.charger.get_archived_sessions(
+                    from_time=last_start - RESUME_MARGIN,
+                    to_time=dt_util.utcnow(),
+                    cursor=cursor,
+                )
+                sessions.extend(page.get("sessions") or [])
+                if not page.get("hasMore"):
+                    break
+                cursor = page.get("cursor")
+        except RequestError as err:
+            if err.error_code == HTTPStatus.FORBIDDEN:
+                # /api/sessions/archived requires the Owner role. Many Zaptec
+                # accounts won't have it on every charger - log once per poll
+                # rather than failing the coordinator every hour.
+                _LOGGER.warning(
+                    "No permission to read charge history for %s (requires Owner role), "
+                    "skipping energy statistics import",
+                    self.charger.qual_id,
+                )
+                return
+            raise UpdateFailed(err) from err
+        except ZaptecApiError as err:
+            raise UpdateFailed(err) from err
+
+        statistics = bucket_sessions_hourly(sessions, after=last_start, running_sum=running_sum)
+        if not statistics:
+            return
+
+        metadata_kwargs: dict[str, Any] = {
+            "mean_type": StatisticMeanType.NONE,
+            "has_sum": True,
+            "name": f"{self.charger.name} Energy",
+            "source": DOMAIN,
+            "statistic_id": self.statistic_id,
+            "unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
+        }
+        if _SUPPORTS_UNIT_CLASS:
+            metadata_kwargs["unit_class"] = EnergyConverter.UNIT_CLASS
+        metadata = StatisticMetaData(**metadata_kwargs)
+        async_add_external_statistics(self.hass, metadata, statistics)
+```
+
+**Update (found live, 2026-07-12):** `unit_class` on `StatisticMetaData`/`StatisticsMeta` is a recent HA core addition — optional-but-recommended as of HA 2026.4.3 (a `report_usage()` deprecation warning if omitted, becoming a hard requirement in HA 2026.11 per that warning's `breaks_in_ha_version`), but genuinely absent as a `StatisticsMeta` column in older HA (confirmed live against a real HA 2025.10.2 devcontainer: passing `unit_class` raises `TypeError: 'unit_class' is an invalid keyword argument for StatisticsMeta`, a hard crash — not a warning — since that HA version's ORM class doesn't have the column at all). Since this integration doesn't pin a minimum HA core version in `manifest.json`, it must support both. Add this module-level feature-detection flag near the top of `statistics.py` (after the imports, before `_floor_hour`), rather than comparing version strings (fragile - the exact version boundary isn't precisely known, feature-detection is robust regardless):
+
+```python
+from homeassistant.components.recorder.db_schema import StatisticsMeta
+
+_SUPPORTS_UNIT_CLASS = hasattr(StatisticsMeta, "unit_class")
+"""Whether the installed HA core's StatisticsMeta accepts unit_class - absent
+on HA < ~2026, a required kwarg (with a deprecation warning if omitted) as of
+2026.4.3, moving to a hard requirement in HA 2026.11. Feature-detected rather
+than version-compared since the exact introduction version isn't pinned down."""
+```
+
+Add `from homeassistant.components.recorder.db_schema import StatisticsMeta` to the imports block above (Task 5 Step 4's header replacement) alongside the existing `homeassistant.components.recorder` imports.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests/test_statistics.py -v`
+Expected: PASS (all tests in the file, 13 total: 7 from Task 4 + 6 coordinator tests from this task)
+
+- [ ] **Step 6: Run full test suite and lint**
+
+Run: `SKIP_ZAPTEC_API_TEST=true "C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests -q`
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m ruff check custom_components/zaptec/statistics.py custom_components/zaptec/const.py tests/test_statistics.py`
+Expected: both clean
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add custom_components/zaptec/statistics.py custom_components/zaptec/const.py tests/test_statistics.py
+git commit -m "feat: add ZaptecStatisticsCoordinator for energy statistics import"
+```
+
+---
+
+### Task 6: Wire into manager/setup, update README
+
+**Files:**
+- Modify: `custom_components/zaptec/manager.py:53-54` (attribute declaration), `:74` (`__init__`)
+- Modify: `custom_components/zaptec/__init__.py:25` (import), `:185-189` (after device coordinators loop)
+- Modify: `README.md:58-63`
+- Create: `tests/test_manager.py` (there is no existing test file for `manager.py`; every other module in `custom_components/zaptec/` has a matching `tests/test_*.py`, so this follows that convention)
+
+**Interfaces:**
+- Consumes: `ZaptecStatisticsCoordinator` (Task 5).
+- Produces: `ZaptecManager.statistics_coordinators: dict[str, ZaptecStatisticsCoordinator]`, populated and first-refreshed during `async_setup_entry`. Nothing downstream depends on this beyond HA's own coordinator lifecycle.
+
+- [ ] **Step 1: Add the attribute to `ZaptecManager`**
+
+In `custom_components/zaptec/manager.py`, add the import:
+
+```python
+from .statistics import ZaptecStatisticsCoordinator
+```
+
+next to the existing `from .coordinator import ZaptecUpdateCoordinator` line. Add the class attribute declaration after `device_coordinators` (currently lines 53-54):
+
+```python
+    statistics_coordinators: dict[str, ZaptecStatisticsCoordinator]
+    """Coordinators that backdate hourly energy statistics, one per tracked charger."""
+```
+
+and initialize it in `__init__` next to `self.device_coordinators = {}` (currently line 74):
+
+```python
+        self.statistics_coordinators = {}
+```
+
+- [ ] **Step 2: Wire creation and first-refresh into `async_setup_entry`**
+
+In `custom_components/zaptec/__init__.py`, add to the import block (near line 25-27):
+
+```python
+from .statistics import ZaptecStatisticsCoordinator
+```
+
+After the existing "Setup the device coordinators for each tracked device" loop (ends at line 185) and before the "Initialize the coordinators" comment (line 187), insert:
+
+```python
+    # Setup the statistics coordinators, one per tracked charger, to backdate
+    # hourly energy consumption into HA's Energy Dashboard statistics (fixes
+    # the live sensor's misattributed-hour delay, see issue #300).
+    for deviceid in tracked_devices:
+        zaptec_obj = zaptec[deviceid]
+        if isinstance(zaptec_obj, Charger):
+            manager.statistics_coordinators[deviceid] = ZaptecStatisticsCoordinator(
+                hass, entry=entry, charger=zaptec_obj
+            )
+```
+
+`Charger` is already imported in `__init__.py` (line 31, `from .zaptec import (..., Installation, ...)` — check the exact import list and add `Charger` alongside `Installation` if it isn't already there; the `isinstance(zaptec_obj, Installation)` check earlier in the same loop above confirms `Installation` is imported, `Charger` needs the same treatment).
+
+Then, separately from the existing "Initialize the coordinators" loop (currently lines 187-189, which is left untouched), add:
+
+```python
+    # First-refresh the statistics coordinators with async_refresh() (not
+    # async_config_entry_first_refresh()) - the latter turns any failure into
+    # ConfigEntryNotReady, aborting setup of the *entire* integration (every
+    # sensor/switch/button) over a hiccup on this secondary, Owner-only
+    # endpoint. async_refresh() logs and marks the coordinator unavailable
+    # instead, so a charge-history outage only degrades the Energy Dashboard
+    # feed, not the whole config entry.
+    for co in manager.statistics_coordinators.values():
+        await co.async_refresh()
+```
+
+Do not add this second loop's body to the existing `all_coordinators` loop above it, and do not change `async_config_entry_first_refresh()` to `async_refresh()` for anything in `all_coordinators` — this distinction is deliberate and specific to the statistics coordinators.
+
+- [ ] **Step 3: Write the test for the new attribute**
+
+Note on scope: `async_setup_entry()` in `__init__.py` (where the actual per-charger creation loop from Step 2 lives) has **no existing unit test coverage** in this repo — `tests/test_init.py` only tests the pure `_config_entry_error()` helper, because exercising `async_setup_entry` needs a real `hass.config_entries`/`ConfigEntry` that (per `conftest.py`'s `FakeConfigEntry` docstring) "pulls in HA's full test-harness machinery, which cannot run on native Windows in this dev environment." This plan doesn't change that boundary. What *is* directly unit-testable is `ZaptecManager.__init__` itself, which is plain Python with no HA config-entry machinery involved.
+
+Create `tests/test_manager.py`:
+
+```python
+"""Tests for manager.py."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from custom_components.zaptec.manager import ZaptecManager
+from custom_components.zaptec.zaptec import Zaptec
+
+
+def test_manager_init_creates_empty_statistics_coordinators(
+    hass: MagicMock, config_entry: Any
+) -> None:
+    """ZaptecManager starts with an empty statistics_coordinators dict."""
+    manager = ZaptecManager(hass, entry=config_entry, zaptec=MagicMock(spec=Zaptec))
+    assert manager.statistics_coordinators == {}
+```
+
+The per-tracked-charger creation loop added to `async_setup_entry()` in Step 2 is validated instead by manual testing (see Step 6) — flag this to the user as a known coverage gap inherited from the existing test suite boundary, not one this plan introduces.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `SKIP_ZAPTEC_API_TEST=true "C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest tests -q`
+Expected: PASS, no regressions
+
+- [ ] **Step 5: Update README known-issues note**
+
+In `README.md`, replace lines 58-63:
+
+```markdown
+* Using the _Energy Meter_ entity as an input to the Energy Dashboard will give values that are delayed by 1 hour
+  in the graphs (see [issue 162](https://github.com/custom-components/zaptec/issues/162) for details).
+  There is a plan to solve this in [issue 300](https://github.com/custom-components/zaptec/issues/300), but until that is implemented,
+  a workaround is to use the more frequently updated _Session total charge_ entity instead. This reduces the delay-issue,
+  but has a separate drawback where a restart of Home Assistant during a charging session can give a fake spike in the logged
+  consumption that needs to be manually edited using "Adjust sum" in the Statistics tab of the Developer tools dashboard.
+```
+
+with:
+
+```markdown
+* Using the _Energy Meter_ entity directly as an input to the Energy Dashboard will still give values delayed by up to an hour
+  in the graphs, since that entity reflects live (polling-delayed) state (see [issue 162](https://github.com/custom-components/zaptec/issues/162)).
+  Each tracked charger now also gets a separate, invisible statistics feed (backdated hourly from Zaptec's charge history,
+  see [issue 300](https://github.com/custom-components/zaptec/issues/300)) that appears in the Energy Dashboard's device picker
+  as "<charger name> Energy" - use that entry instead of _Energy Meter_ or _Session total charge_ for accurate,
+  correctly-timed consumption graphs.
+```
+
+- [ ] **Step 6: Final full verification**
+
+Run: `SKIP_ZAPTEC_API_TEST=true "C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m pytest --cov=./custom_components/zaptec --cov-branch tests`
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m ruff format custom_components tests --diff`
+Run: `"C:/Users/rhamm/anaconda3/envs/py314/python.exe" -m ruff check custom_components tests`
+Expected: tests pass (aside from the known `test_zconst.py`/`test_redact.py` DNS gap per CLAUDE.md), format diff empty, no new ruff errors beyond the pre-existing ~76-error baseline in `zaptec/api.py`
+
+Then manually verify the actual `async_setup_entry()` wiring (Step 2), since it has no automated coverage: run Home Assistant in the devcontainer against a real account (F1 → "Tasks: Run Task" → "Run Home Assistant on port 8123", per `DEVELOPMENT.md`), check the HA log for one `zaptec-statistics-Charger[...]` coordinator refresh per configured charger, then check Developer Tools → Statistics for a new `<charger name> Energy` entry with populated hourly values.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add custom_components/zaptec/manager.py custom_components/zaptec/__init__.py README.md tests/test_manager.py
+git commit -m "feat: wire up ZaptecStatisticsCoordinator per tracked charger"
+```
+
+---
+
+## Follow-up (not in this plan)
+
+- Once merged and confirmed working against a real account (Task 3 Step 5's live smoke test, plus watching a real Energy Dashboard for a day), consider filing a small doc PR against upstream to close #300, referencing this implementation.
+- If `bucket_sessions_hourly()`'s hour-boundary approximation (Task 4) turns out to matter in practice (e.g. long sessions with sparse detail points), a follow-up could split deltas proportionally by time overlap instead of assigning them wholly to the later hour — deliberately deferred as YAGNI for v1.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,58 @@
 
 import asyncio
 import os
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 from custom_components.zaptec.zaptec.api import Zaptec
+
+
+class FakeConfigEntry:
+    """Minimal stand-in for HA's ConfigEntry.
+
+    Exposes only what coordinator.py and entity.py actually touch
+    (`pref_disable_polling`, `async_on_unload`,
+    `async_create_background_task`). A real ConfigEntry pulls in HA's full
+    test-harness machinery, which cannot run on native Windows in this dev
+    environment - see CLAUDE.md's environment notes.
+    """
+
+    pref_disable_polling = False
+    title = "Mock Title"
+
+    def async_on_unload(self, func: Any) -> None:
+        """Record an unload callback. Never invoked by these tests."""
+
+    def async_create_background_task(
+        self, hass: Any, target: Any, name: str, eager_start: bool = True
+    ) -> asyncio.Task:
+        """Schedule target as a real asyncio Task.
+
+        This ensures trigger_poll()'s cancel-and-replace logic is genuinely
+        exercised by tests.
+        """
+        return asyncio.ensure_future(target)
+
+
+@pytest.fixture
+def config_entry() -> FakeConfigEntry:
+    """A fake config entry for coordinator/entity tests."""
+    return FakeConfigEntry()
+
+
+@pytest.fixture
+async def hass() -> MagicMock:
+    """A minimal fake HomeAssistant object exposing a real running event loop.
+
+    DataUpdateCoordinator only reads `hass.loop` (to schedule refreshes via
+    `loop.call_at()`/`loop.time()`); coordinator.py and entity.py never touch
+    any other HomeAssistant functionality (config, states, services, etc.).
+    """
+    fake_hass = MagicMock()
+    fake_hass.loop = asyncio.get_running_loop()
+    return fake_hass
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ class FakeConfigEntry:
     title = "Mock Title"
 
     def async_on_unload(self, func: Any) -> None:
-        """Record an unload callback. Never invoked by these tests."""
+        """No-op stand-in for HA's unload-callback registration. Never invoked by these tests."""
 
     def async_create_background_task(
         self, hass: Any, target: Any, name: str, eager_start: bool = True
@@ -50,9 +50,12 @@ async def hass() -> MagicMock:
     DataUpdateCoordinator only reads `hass.loop` (to schedule refreshes via
     `loop.call_at()`/`loop.time()`); coordinator.py and entity.py never touch
     any other HomeAssistant functionality (config, states, services, etc.).
+    `is_stopping` is pinned False to match a real (non-shutting-down)
+    HomeAssistant instance, since a bare MagicMock would otherwise be truthy.
     """
     fake_hass = MagicMock()
     fake_hass.loop = asyncio.get_running_loop()
+    fake_hass.is_stopping = False
     return fake_hass
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,68 @@
+"""Tests for binary_sensor.py."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from homeassistant.helpers.entity import DeviceInfo
+import pytest
+
+from custom_components.zaptec.binary_sensor import (
+    ZapBinarySensorEntityDescription,
+    ZaptecBinarySensor,
+    ZaptecBinarySensorWithAttrs,
+)
+from custom_components.zaptec.coordinator import ZaptecUpdateCoordinator, ZaptecUpdateOptions
+from custom_components.zaptec.zaptec import Charger
+
+
+@pytest.fixture
+def coordinator(hass: MagicMock, config_entry: Any) -> ZaptecUpdateCoordinator:
+    """Create a ZaptecUpdateCoordinator for testing."""
+    manager = MagicMock()
+    options = ZaptecUpdateOptions(
+        name="test",
+        update_interval=600,
+        charging_update_interval=None,
+        tracked_devices=set(),
+        poll_args={},
+        zaptec_object=None,
+    )
+    return ZaptecUpdateCoordinator(hass, entry=config_entry, manager=manager, options=options)
+
+
+def make_charger(data: dict[str, Any]) -> MagicMock:
+    """Create a MagicMock(spec=Charger) whose .get() reads from data."""
+    charger = MagicMock(spec=Charger)
+    charger.id = "charger1"
+    charger.qual_id = "Charger[charger1]"
+    charger.get.side_effect = data.get
+    return charger
+
+
+def test_binary_sensor_update_from_zaptec_sets_is_on(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecBinarySensor._update_from_zaptec reads the raw boolean value for its key."""
+    charger = make_charger({"is_online": True})
+    description = ZapBinarySensorEntityDescription(key="is_online", cls=ZaptecBinarySensor)
+    entity = ZaptecBinarySensor(coordinator, charger, description, DeviceInfo())
+
+    entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_is_on is True  # noqa: SLF001
+    assert entity._attr_available is True  # noqa: SLF001
+
+
+def test_binary_sensor_with_attrs_post_init_sets_attrs_and_unique_id(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecBinarySensorWithAttrs._post_init copies all raw attrs and overrides unique_id."""
+    charger = make_charger({})
+    charger.asdict.return_value = {"Id": "charger1", "Active": True}
+    description = ZapBinarySensorEntityDescription(key="active", cls=ZaptecBinarySensorWithAttrs)
+    entity = ZaptecBinarySensorWithAttrs(coordinator, charger, description, DeviceInfo())
+
+    assert entity._attr_extra_state_attributes == {"Id": "charger1", "Active": True}  # noqa: SLF001
+    assert entity._attr_unique_id == "charger1"  # noqa: SLF001

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,91 @@
+"""Tests for button.py."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+import pytest
+
+from custom_components.zaptec.button import ZapButtonEntityDescription, ZaptecButton
+from custom_components.zaptec.coordinator import ZaptecUpdateCoordinator, ZaptecUpdateOptions
+from custom_components.zaptec.zaptec import Charger
+
+
+@pytest.fixture
+def coordinator(hass: MagicMock, config_entry: Any) -> ZaptecUpdateCoordinator:
+    """Create a ZaptecUpdateCoordinator for testing."""
+    manager = MagicMock()
+    options = ZaptecUpdateOptions(
+        name="test",
+        update_interval=600,
+        charging_update_interval=None,
+        tracked_devices=set(),
+        poll_args={},
+        zaptec_object=None,
+    )
+    return ZaptecUpdateCoordinator(hass, entry=config_entry, manager=manager, options=options)
+
+
+def make_charger(data: dict[str, Any]) -> MagicMock:
+    """Create a MagicMock(spec=Charger) whose .get() reads from data."""
+    charger = MagicMock(spec=Charger)
+    charger.id = "charger1"
+    charger.qual_id = "Charger[charger1]"
+    charger.get.side_effect = data.get
+    return charger
+
+
+def test_button_available_delegates_to_is_command_valid(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecButton.available checks is_command_valid using its own key as the command."""
+    charger = make_charger({})
+    charger.is_command_valid.return_value = True
+    description = ZapButtonEntityDescription(key="restart_charger", cls=ZaptecButton)
+    entity = ZaptecButton(coordinator, charger, description, DeviceInfo())
+
+    assert entity.available is True
+    charger.is_command_valid.assert_called_once_with("restart_charger")
+
+
+def test_button_unavailable_when_command_invalid(coordinator: ZaptecUpdateCoordinator) -> None:
+    """ZaptecButton.available is False when is_command_valid returns False."""
+    charger = make_charger({})
+    charger.is_command_valid.return_value = False
+    description = ZapButtonEntityDescription(key="resume_charging", cls=ZaptecButton)
+    entity = ZaptecButton(coordinator, charger, description, DeviceInfo())
+
+    assert entity.available is False
+
+
+async def test_button_press_sends_command_and_polls(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_press sends the command named by the button's key and triggers a poll."""
+    charger = make_charger({})
+    charger.command = AsyncMock()
+    description = ZapButtonEntityDescription(key="restart_charger", cls=ZaptecButton)
+    entity = ZaptecButton(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    await entity.async_press()
+
+    charger.command.assert_awaited_once_with("restart_charger")
+    entity.trigger_poll.assert_awaited_once()
+
+
+async def test_button_press_wraps_command_failure(coordinator: ZaptecUpdateCoordinator) -> None:
+    """async_press wraps a command failure in HomeAssistantError and skips the poll."""
+    charger = make_charger({})
+    charger.command = AsyncMock(side_effect=Exception("boom"))
+    description = ZapButtonEntityDescription(key="restart_charger", cls=ZaptecButton)
+    entity = ZaptecButton(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_press()
+
+    entity.trigger_poll.assert_not_called()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -117,7 +117,6 @@ async def test_set_update_interval_is_noop_when_unchanged(
     """Test that set_update_interval doesn't reschedule when interval is unchanged."""
     charger = MagicMock(spec=Charger)
     charger.is_charging.return_value = False
-    charger.qual_id = "Charger[abc123]"
     options = make_options(
         update_interval=600,
         charging_update_interval=60,
@@ -154,14 +153,16 @@ async def test_async_update_data_raises_update_failed_on_api_error(
     hass: MagicMock, config_entry: Any, manager: MagicMock
 ) -> None:
     """Test that _async_update_data raises UpdateFailed on ZaptecApiError."""
-    manager.zaptec.poll = AsyncMock(side_effect=ZaptecApiError("boom"))
+    api_error = ZaptecApiError("boom")
+    manager.zaptec.poll = AsyncMock(side_effect=api_error)
     options = make_options()
     coordinator = ZaptecUpdateCoordinator(
         hass, entry=config_entry, manager=manager, options=options
     )
 
-    with pytest.raises(UpdateFailed):
+    with pytest.raises(UpdateFailed) as exc_info:
         await coordinator._async_update_data()  # noqa: SLF001
+    assert exc_info.value.__cause__ is api_error
 
 
 async def test_trigger_poll_charger_uses_charger_delays(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,79 @@
+"""Tests for coordinator.py."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.zaptec.const import DOMAIN
+from custom_components.zaptec.coordinator import ZaptecUpdateCoordinator, ZaptecUpdateOptions
+from custom_components.zaptec.zaptec import Charger, Installation, Zaptec
+
+
+@pytest.fixture
+def manager() -> MagicMock:
+    """A fake ZaptecManager exposing only what the coordinator touches."""
+    mgr = MagicMock()
+    mgr.zaptec = MagicMock(spec=Zaptec)
+    mgr.device_coordinators = {}
+    mgr.tracked_devices = set()
+    return mgr
+
+
+def make_options(**overrides: Any) -> ZaptecUpdateOptions:
+    """Build ZaptecUpdateOptions with sane defaults, overridable per test."""
+    defaults: dict[str, Any] = {
+        "name": "test",
+        "update_interval": 600,
+        "charging_update_interval": None,
+        "tracked_devices": {"dev1"},
+        "poll_args": {},
+        "zaptec_object": None,
+    }
+    defaults.update(overrides)
+    return ZaptecUpdateOptions(**defaults)
+
+
+async def test_init_sets_name_and_default_interval(
+    hass: MagicMock, config_entry: Any, manager: MagicMock
+) -> None:
+    """Test that coordinator init sets name and update interval correctly."""
+    options = make_options(name="MyInstall", update_interval=300)
+    coordinator = ZaptecUpdateCoordinator(
+        hass, entry=config_entry, manager=manager, options=options
+    )
+
+    assert coordinator.name == f"{DOMAIN}-myinstall"
+    assert coordinator.update_interval == timedelta(seconds=300)
+    assert coordinator.zaptec is manager.zaptec
+
+
+async def test_init_raises_if_charging_interval_without_charger(
+    hass: MagicMock, config_entry: Any, manager: MagicMock
+) -> None:
+    """Test that charging interval requires a Charger object."""
+    options = make_options(
+        charging_update_interval=60,
+        zaptec_object=MagicMock(spec=Installation),
+    )
+
+    with pytest.raises(ValueError, match="Charging update interval requires a Charger object"):
+        ZaptecUpdateCoordinator(hass, entry=config_entry, manager=manager, options=options)
+
+
+async def test_init_accepts_charging_interval_with_charger(
+    hass: MagicMock, config_entry: Any, manager: MagicMock
+) -> None:
+    """Test that charging interval is accepted when a Charger object is provided."""
+    charger = MagicMock(spec=Charger)
+    charger.is_charging.return_value = False
+    options = make_options(charging_update_interval=60, zaptec_object=charger)
+
+    coordinator = ZaptecUpdateCoordinator(
+        hass, entry=config_entry, manager=manager, options=options
+    )
+
+    assert coordinator._charging_update_interval == timedelta(seconds=60)  # noqa: SLF001

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -9,7 +10,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant.helpers.update_coordinator import UpdateFailed
 import pytest
 
-from custom_components.zaptec.const import DOMAIN
+from custom_components.zaptec.const import (
+    DOMAIN,
+    ZAPTEC_POLL_CHARGER_TRIGGER_DELAYS,
+    ZAPTEC_POLL_INSTALLATION_TRIGGER_DELAYS,
+)
 from custom_components.zaptec.coordinator import ZaptecUpdateCoordinator, ZaptecUpdateOptions
 from custom_components.zaptec.zaptec import Charger, Installation, Zaptec, ZaptecApiError
 
@@ -157,3 +162,136 @@ async def test_async_update_data_raises_update_failed_on_api_error(
 
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()  # noqa: SLF001
+
+
+async def test_trigger_poll_charger_uses_charger_delays(
+    hass: MagicMock, config_entry: Any, manager: MagicMock
+) -> None:
+    """Test that _trigger_poll sleeps/refreshes once per charger delay."""
+    charger = MagicMock(spec=Charger)
+    charger.qual_id = "Charger[abc123]"
+    options = make_options(zaptec_object=charger)
+    coordinator = ZaptecUpdateCoordinator(
+        hass, entry=config_entry, manager=manager, options=options
+    )
+
+    with (
+        patch("custom_components.zaptec.coordinator.asyncio.sleep", AsyncMock()) as mock_sleep,
+        patch.object(coordinator, "async_refresh", AsyncMock()) as mock_refresh,
+    ):
+        await coordinator._trigger_poll(charger)  # noqa: SLF001
+
+    assert mock_sleep.await_count == len(ZAPTEC_POLL_CHARGER_TRIGGER_DELAYS)
+    assert mock_refresh.await_count == len(ZAPTEC_POLL_CHARGER_TRIGGER_DELAYS)
+
+
+async def test_trigger_poll_installation_also_triggers_tracked_children(
+    hass: MagicMock, config_entry: Any, manager: MagicMock
+) -> None:
+    """Test that _trigger_poll on an Installation also polls tracked child chargers."""
+    charger = MagicMock(spec=Charger)
+    charger.id = "charger1"
+    installation = MagicMock(spec=Installation)
+    installation.qual_id = "Installation[abc123]"
+    installation.chargers = [charger]
+    manager.tracked_devices = {"charger1"}
+
+    child_coordinator = MagicMock()
+    child_coordinator.trigger_poll = AsyncMock()
+    manager.device_coordinators = {"charger1": child_coordinator}
+
+    options = make_options(zaptec_object=installation)
+    coordinator = ZaptecUpdateCoordinator(
+        hass, entry=config_entry, manager=manager, options=options
+    )
+
+    with (
+        patch("custom_components.zaptec.coordinator.asyncio.sleep", AsyncMock()) as mock_sleep,
+        patch.object(coordinator, "async_refresh", AsyncMock()) as mock_refresh,
+    ):
+        await coordinator._trigger_poll(installation)  # noqa: SLF001
+
+    assert mock_sleep.await_count == len(ZAPTEC_POLL_INSTALLATION_TRIGGER_DELAYS)
+    assert mock_refresh.await_count == len(ZAPTEC_POLL_INSTALLATION_TRIGGER_DELAYS)
+    child_coordinator.trigger_poll.assert_awaited_once()
+
+
+async def test_trigger_poll_installation_skips_untracked_children(
+    hass: MagicMock, config_entry: Any, manager: MagicMock
+) -> None:
+    """Test that _trigger_poll skips children that aren't in tracked_devices."""
+    charger = MagicMock(spec=Charger)
+    charger.id = "charger1"
+    installation = MagicMock(spec=Installation)
+    installation.qual_id = "Installation[abc123]"
+    installation.chargers = [charger]
+    manager.tracked_devices = set()  # charger1 is not tracked
+
+    options = make_options(zaptec_object=installation)
+    coordinator = ZaptecUpdateCoordinator(
+        hass, entry=config_entry, manager=manager, options=options
+    )
+
+    with (
+        patch("custom_components.zaptec.coordinator.asyncio.sleep", AsyncMock()),
+        patch.object(coordinator, "async_refresh", AsyncMock()),
+    ):
+        # Would raise KeyError from manager.device_coordinators[charger.id] if
+        # the untracked charger were not filtered out first.
+        await coordinator._trigger_poll(installation)  # noqa: SLF001
+
+
+async def test_trigger_poll_noop_without_zaptec_object(
+    hass: MagicMock, config_entry: Any, manager: MagicMock
+) -> None:
+    """Test that trigger_poll is a no-op when there is no zaptec_object."""
+    options = make_options(zaptec_object=None)
+    coordinator = ZaptecUpdateCoordinator(
+        hass, entry=config_entry, manager=manager, options=options
+    )
+
+    await coordinator.trigger_poll()
+
+    assert coordinator._trigger_task is None  # noqa: SLF001
+
+
+async def test_trigger_poll_cancels_inflight_task_before_starting_new_one(
+    hass: MagicMock, config_entry: Any, manager: MagicMock
+) -> None:
+    """Test that a second trigger_poll cancels the in-flight task and starts a new one."""
+    charger = MagicMock(spec=Charger)
+    charger.qual_id = "Charger[abc123]"
+    options = make_options(zaptec_object=charger)
+    coordinator = ZaptecUpdateCoordinator(
+        hass, entry=config_entry, manager=manager, options=options
+    )
+
+    call_count = 0
+    first_started = asyncio.Event()
+
+    async def fake_trigger_poll(_zaptec_obj: Any) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            first_started.set()
+            await asyncio.Event().wait()  # blocks forever, until cancelled
+
+    with patch.object(coordinator, "_trigger_poll", fake_trigger_poll):
+        await coordinator.trigger_poll()
+        await first_started.wait()
+        first_task = coordinator._trigger_task  # noqa: SLF001
+        assert first_task is not None
+        assert not first_task.done()
+
+        await coordinator.trigger_poll()
+
+        assert first_task.cancelled()
+        # Two loop iterations are required here: the first lets the second
+        # task run to completion; the second lets its done-callback (which
+        # clears coordinator._trigger_task) actually fire, since
+        # Task.add_done_callback schedules callbacks via call_soon rather
+        # than invoking them synchronously on completion.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)  # let the second task's done-callback run
+        assert coordinator._trigger_task is None  # noqa: SLF001
+        assert call_count == 2  # noqa: PLR2004

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -77,3 +77,50 @@ async def test_init_accepts_charging_interval_with_charger(
     )
 
     assert coordinator._charging_update_interval == timedelta(seconds=60)  # noqa: SLF001
+
+
+async def test_set_update_interval_switches_between_charging_and_default(
+    hass: MagicMock, config_entry: Any, manager: MagicMock
+) -> None:
+    """Test that set_update_interval switches between charging and default intervals."""
+    charger = MagicMock(spec=Charger)
+    charger.is_charging.return_value = False
+    charger.qual_id = "Charger[abc123]"
+    options = make_options(
+        update_interval=600,
+        charging_update_interval=60,
+        zaptec_object=charger,
+    )
+    coordinator = ZaptecUpdateCoordinator(
+        hass, entry=config_entry, manager=manager, options=options
+    )
+    assert coordinator.update_interval == timedelta(seconds=600)
+
+    charger.is_charging.return_value = True
+    coordinator.set_update_interval()
+    assert coordinator.update_interval == timedelta(seconds=60)
+
+    charger.is_charging.return_value = False
+    coordinator.set_update_interval()
+    assert coordinator.update_interval == timedelta(seconds=600)
+
+
+async def test_set_update_interval_is_noop_when_unchanged(
+    hass: MagicMock, config_entry: Any, manager: MagicMock
+) -> None:
+    """Test that set_update_interval doesn't reschedule when interval is unchanged."""
+    charger = MagicMock(spec=Charger)
+    charger.is_charging.return_value = False
+    charger.qual_id = "Charger[abc123]"
+    options = make_options(
+        update_interval=600,
+        charging_update_interval=60,
+        zaptec_object=charger,
+    )
+    coordinator = ZaptecUpdateCoordinator(
+        hass, entry=config_entry, manager=manager, options=options
+    )
+
+    with patch.object(coordinator, "_schedule_refresh") as mock_schedule:
+        coordinator.set_update_interval()
+        mock_schedule.assert_not_called()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from datetime import timedelta
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.helpers.update_coordinator import UpdateFailed
 import pytest
 
 from custom_components.zaptec.const import DOMAIN
 from custom_components.zaptec.coordinator import ZaptecUpdateCoordinator, ZaptecUpdateOptions
-from custom_components.zaptec.zaptec import Charger, Installation, Zaptec
+from custom_components.zaptec.zaptec import Charger, Installation, Zaptec, ZaptecApiError
 
 
 @pytest.fixture
@@ -124,3 +125,35 @@ async def test_set_update_interval_is_noop_when_unchanged(
     with patch.object(coordinator, "_schedule_refresh") as mock_schedule:
         coordinator.set_update_interval()
         mock_schedule.assert_not_called()
+
+
+async def test_async_update_data_polls_zaptec_with_options(
+    hass: MagicMock, config_entry: Any, manager: MagicMock
+) -> None:
+    """Test that _async_update_data calls zaptec.poll with correct parameters."""
+    manager.zaptec.poll = AsyncMock()
+    options = make_options(
+        tracked_devices={"dev1", "dev2"},
+        poll_args={"poll_state": True},
+    )
+    coordinator = ZaptecUpdateCoordinator(
+        hass, entry=config_entry, manager=manager, options=options
+    )
+
+    await coordinator._async_update_data()  # noqa: SLF001
+
+    manager.zaptec.poll.assert_awaited_once_with({"dev1", "dev2"}, poll_state=True)
+
+
+async def test_async_update_data_raises_update_failed_on_api_error(
+    hass: MagicMock, config_entry: Any, manager: MagicMock
+) -> None:
+    """Test that _async_update_data raises UpdateFailed on ZaptecApiError."""
+    manager.zaptec.poll = AsyncMock(side_effect=ZaptecApiError("boom"))
+    options = make_options()
+    coordinator = ZaptecUpdateCoordinator(
+        hass, entry=config_entry, manager=manager, options=options
+    )
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()  # noqa: SLF001

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -110,6 +110,7 @@ def test_get_zaptec_value_raises_when_object_is_not_a_mapping(entity: ZaptecBase
     class NotMapping:
         @property
         def qual_id(self) -> str:
+            """Return a fake qualified id."""
             return "NotMapping[test]"
 
     entity.zaptec_obj = NotMapping()

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -115,3 +116,183 @@ def test_get_zaptec_value_raises_when_object_is_not_a_mapping(entity: ZaptecBase
 
     with pytest.raises(KeyUnavailableError):
         entity._get_zaptec_value(key="operating_mode")  # noqa: SLF001
+
+
+def test_handle_coordinator_update_success_updates_value_and_writes_state(
+    entity: ZaptecBaseEntity, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a successful update logs the new value and writes HA state."""
+    entity.entity_id = "sensor.test"
+    entity.async_write_ha_state = MagicMock()
+    entity._log_attribute = "some_attr"  # noqa: SLF001
+    entity.some_attr = "new_value"
+    entity._update_from_zaptec = lambda: None  # noqa: SLF001
+
+    with caplog.at_level(logging.DEBUG):
+        entity._handle_coordinator_update()  # noqa: SLF001
+
+    entity.async_write_ha_state.assert_called_once()
+    assert "new_value" in caplog.text
+
+
+def test_handle_coordinator_update_key_unavailable_sets_attr_available_false(
+    entity: ZaptecBaseEntity, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a KeyUnavailableError during update marks the entity unavailable."""
+    entity.entity_id = "sensor.test"
+    entity.async_write_ha_state = MagicMock()
+
+    def raise_unavailable() -> None:
+        raise KeyUnavailableError("operating_mode", "boom")
+
+    entity._update_from_zaptec = raise_unavailable  # noqa: SLF001
+
+    with caplog.at_level(logging.INFO):
+        entity._handle_coordinator_update()  # noqa: SLF001
+
+    # NOTE: this sets _attr_available, but ZaptecBaseEntity does not override
+    # the `available` property inherited from HA's CoordinatorEntity (which
+    # returns coordinator.last_update_success instead), so this flag currently
+    # has no effect on the entity's actual reported availability. This test
+    # documents today's real behavior, not the intended one - see the "Known
+    # finding" note at the top of this plan.
+    assert entity._attr_available is False  # noqa: SLF001
+    assert "sensor.test is unavailable" in caplog.text
+    entity.async_write_ha_state.assert_called_once()
+
+
+def test_log_zaptec_attribute_formats_string_key(entity: ZaptecBaseEntity) -> None:
+    """Test that _log_zaptec_attribute formats a string key with a leading dot."""
+    entity._log_zaptec_key = "operating_mode"  # noqa: SLF001
+    assert entity._log_zaptec_attribute == ".operating_mode"  # noqa: SLF001
+
+
+def test_log_zaptec_attribute_formats_none_key(entity: ZaptecBaseEntity) -> None:
+    """Test that _log_zaptec_attribute returns an empty string when the key is None."""
+    entity._log_zaptec_key = None  # noqa: SLF001
+    assert entity._log_zaptec_attribute == ""  # noqa: SLF001
+
+
+def test_log_zaptec_attribute_formats_iterable_key(entity: ZaptecBaseEntity) -> None:
+    """Test that _log_zaptec_attribute joins iterable keys with 'and'."""
+    entity._log_zaptec_key = ["mode", "state"]  # noqa: SLF001
+    assert entity._log_zaptec_attribute == ".mode and .state"  # noqa: SLF001
+
+
+def test_log_value_logs_on_change(
+    entity: ZaptecBaseEntity, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that _log_value logs when the value has changed."""
+    entity.entity_id = "sensor.test"
+    entity.some_attr = "value1"
+
+    with caplog.at_level(logging.DEBUG):
+        entity._log_value("some_attr")  # noqa: SLF001
+
+    assert "value1" in caplog.text
+    assert entity._prev_value == "value1"  # noqa: SLF001
+
+
+def test_log_value_skips_logging_when_unchanged(
+    entity: ZaptecBaseEntity, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that _log_value skips logging when the value is unchanged."""
+    entity.entity_id = "sensor.test"
+    entity.some_attr = "value1"
+    entity._prev_value = "value1"  # noqa: SLF001
+
+    with caplog.at_level(logging.DEBUG):
+        entity._log_value("some_attr")  # noqa: SLF001
+
+    assert caplog.text == ""
+
+
+def test_log_value_force_logs_even_when_unchanged(
+    entity: ZaptecBaseEntity, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that _log_value logs even when unchanged if force is True."""
+    entity.entity_id = "sensor.test"
+    entity.some_attr = "value1"
+    entity._prev_value = "value1"  # noqa: SLF001
+
+    with caplog.at_level(logging.DEBUG):
+        entity._log_value("some_attr", force=True)  # noqa: SLF001
+
+    assert "value1" in caplog.text
+
+
+def test_log_value_noop_for_none_attribute(
+    entity: ZaptecBaseEntity, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that _log_value is a no-op when the attribute is None."""
+    with caplog.at_level(logging.DEBUG):
+        entity._log_value(None)  # noqa: SLF001
+
+    assert caplog.text == ""
+
+
+def test_log_unavailable_logs_on_transition_to_unavailable(
+    entity: ZaptecBaseEntity, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that _log_unavailable logs when the entity transitions to unavailable."""
+    entity.entity_id = "sensor.test"
+    entity._attr_available = False  # noqa: SLF001
+
+    with caplog.at_level(logging.DEBUG):
+        entity._log_unavailable()  # noqa: SLF001
+
+    assert "Entity sensor.test is unavailable" in caplog.text
+
+
+def test_log_unavailable_logs_error_for_unexpected_exception(
+    entity: ZaptecBaseEntity, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that _log_unavailable logs an error for an unexpected exception."""
+    entity.entity_id = "sensor.test"
+    entity._attr_available = False  # noqa: SLF001
+
+    with caplog.at_level(logging.DEBUG):
+        entity._log_unavailable(exception=ValueError("boom"))  # noqa: SLF001
+
+    assert "Getting value failed" in caplog.text
+
+
+def test_log_unavailable_skips_error_for_key_unavailable_error(
+    entity: ZaptecBaseEntity, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that _log_unavailable skips the error log for KeyUnavailableError."""
+    entity.entity_id = "sensor.test"
+    entity._attr_available = False  # noqa: SLF001
+
+    with caplog.at_level(logging.DEBUG):
+        entity._log_unavailable(exception=KeyUnavailableError("some_key", "boom"))  # noqa: SLF001
+
+    assert "Getting value failed" not in caplog.text
+
+
+def test_log_unavailable_skips_error_for_keys_in_skip_set(
+    entity: ZaptecBaseEntity, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that _log_unavailable skips the error log for keys in the skip set."""
+    entity.entity_id = "sensor.test"
+    entity.entity_description = EntityDescription(key="three_to_one_phase_switch_current")
+    entity._attr_available = False  # noqa: SLF001
+
+    with caplog.at_level(logging.DEBUG):
+        entity._log_unavailable(exception=ValueError("boom"))  # noqa: SLF001
+
+    assert "Getting value failed" not in caplog.text
+
+
+def test_log_unavailable_logs_on_recovery(
+    entity: ZaptecBaseEntity, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that _log_unavailable logs when the entity recovers to available."""
+    entity.entity_id = "sensor.test"
+    entity._prev_available = False  # noqa: SLF001
+    entity._attr_available = True  # noqa: SLF001
+
+    with caplog.at_level(logging.INFO):
+        entity._log_unavailable()  # noqa: SLF001
+
+    assert "Entity sensor.test is available" in caplog.text

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
 import pytest
@@ -296,3 +296,14 @@ def test_log_unavailable_logs_on_recovery(
         entity._log_unavailable()  # noqa: SLF001
 
     assert "Entity sensor.test is available" in caplog.text
+
+
+async def test_trigger_poll_delegates_to_coordinator(
+    entity: ZaptecBaseEntity, coordinator: ZaptecUpdateCoordinator
+) -> None:
+    """Test that trigger_poll delegates to coordinator.trigger_poll."""
+    coordinator.trigger_poll = AsyncMock()
+
+    await entity.trigger_poll()
+
+    coordinator.trigger_poll.assert_awaited_once()

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,117 @@
+"""Tests for entity.py."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from homeassistant.helpers.entity import DeviceInfo, EntityDescription
+import pytest
+
+from custom_components.zaptec.coordinator import ZaptecUpdateCoordinator, ZaptecUpdateOptions
+from custom_components.zaptec.entity import KeyUnavailableError, ZaptecBaseEntity
+from custom_components.zaptec.zaptec import MISSING
+
+
+class FakeZaptecObj:
+    """Minimal stand-in for a ZaptecBase object, exposing only what ZaptecBaseEntity uses."""
+
+    def __init__(self, obj_id: str, data: dict[str, Any]) -> None:
+        """Initialize the FakeZaptecObj."""
+        self.id = obj_id
+        self._data = data
+
+    @property
+    def qual_id(self) -> str:
+        """Return the qualified id."""
+        return f"Fake[{self.id}]"
+
+    def get(self, key: str, default: Any = MISSING) -> Any:
+        """Get a value from the data dict."""
+        return self._data.get(key, default)
+
+
+@pytest.fixture
+def coordinator(hass: MagicMock, config_entry: Any) -> ZaptecUpdateCoordinator:
+    """Create a ZaptecUpdateCoordinator for testing."""
+    manager = MagicMock()
+    options = ZaptecUpdateOptions(
+        name="test",
+        update_interval=600,
+        charging_update_interval=None,
+        tracked_devices=set(),
+        poll_args={},
+        zaptec_object=None,
+    )
+    return ZaptecUpdateCoordinator(hass, entry=config_entry, manager=manager, options=options)
+
+
+@pytest.fixture
+def zaptec_obj() -> FakeZaptecObj:
+    """Create a FakeZaptecObj for testing."""
+    return FakeZaptecObj(
+        "dev1",
+        {"operating_mode": "Connected", "nested": {"inner": "value"}},
+    )
+
+
+@pytest.fixture
+def entity(coordinator: ZaptecUpdateCoordinator, zaptec_obj: FakeZaptecObj) -> ZaptecBaseEntity:
+    """Create a ZaptecBaseEntity for testing."""
+    description = EntityDescription(key="operating_mode")
+    return ZaptecBaseEntity(coordinator, zaptec_obj, description, DeviceInfo())
+
+
+def test_init_sets_unique_id_device_info_and_log_key(
+    entity: ZaptecBaseEntity, zaptec_obj: FakeZaptecObj
+) -> None:
+    """Test that init sets _attr_unique_id, _attr_device_info, and _log_zaptec_key."""
+    assert entity._attr_unique_id == "dev1_operating_mode"  # noqa: SLF001
+    assert entity._attr_device_info == DeviceInfo()  # noqa: SLF001
+    assert entity._log_zaptec_key == "operating_mode"  # noqa: SLF001
+
+
+def test_key_property_returns_description_key(entity: ZaptecBaseEntity) -> None:
+    """Test that key property returns the entity description key."""
+    assert entity.key == "operating_mode"
+
+
+def test_get_zaptec_value_returns_value(entity: ZaptecBaseEntity) -> None:
+    """Test that _get_zaptec_value returns the value from zaptec_obj."""
+    assert entity._get_zaptec_value() == "Connected"  # noqa: SLF001
+
+
+def test_get_zaptec_value_lower_cases_string(entity: ZaptecBaseEntity) -> None:
+    """Test that _get_zaptec_value lower cases strings when requested."""
+    assert entity._get_zaptec_value(lower_case_str=True) == "connected"  # noqa: SLF001
+
+
+def test_get_zaptec_value_follows_dotted_key(entity: ZaptecBaseEntity) -> None:
+    """Test that _get_zaptec_value follows dotted keys."""
+    assert entity._get_zaptec_value(key="nested.inner") == "value"  # noqa: SLF001
+
+
+def test_get_zaptec_value_returns_default_without_raising(entity: ZaptecBaseEntity) -> None:
+    """Test that _get_zaptec_value returns default when key is missing."""
+    assert entity._get_zaptec_value(key="missing_key", default="fallback") == "fallback"  # noqa: SLF001
+
+
+def test_get_zaptec_value_raises_when_key_missing(entity: ZaptecBaseEntity) -> None:
+    """Test that _get_zaptec_value raises KeyUnavailableError for missing keys."""
+    with pytest.raises(KeyUnavailableError) as exc_info:
+        entity._get_zaptec_value(key="missing_key")  # noqa: SLF001
+    assert exc_info.value.key == "missing_key"
+
+
+def test_get_zaptec_value_raises_when_object_is_not_a_mapping(entity: ZaptecBaseEntity) -> None:
+    """Test that _get_zaptec_value raises KeyUnavailableError when zaptec_obj is not a mapping."""
+
+    class NotMapping:
+        @property
+        def qual_id(self) -> str:
+            return "NotMapping[test]"
+
+    entity.zaptec_obj = NotMapping()
+
+    with pytest.raises(KeyUnavailableError):
+        entity._get_zaptec_value(key="operating_mode")  # noqa: SLF001

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,35 @@
+"""Tests for custom_components.zaptec.__init__."""
+
+from http import HTTPStatus
+
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryError, ConfigEntryNotReady
+import pytest
+
+from custom_components.zaptec import _config_entry_error
+from custom_components.zaptec.zaptec.exceptions import (
+    AuthenticationError,
+    RequestConnectionError,
+    RequestError,
+    RequestTimeoutError,
+)
+
+
+@pytest.mark.parametrize(
+    ("err", "expected"),
+    [
+        # Bad credentials are non-recoverable -> re-auth flow.
+        (AuthenticationError("bad"), ConfigEntryAuthFailed),
+        # Connection/timeout are recoverable -> HA retries setup.
+        (RequestTimeoutError("slow"), ConfigEntryNotReady),
+        (RequestConnectionError("down"), ConfigEntryNotReady),
+        # Transient server statuses are recoverable -> HA retries setup (issue #392).
+        (RequestError("unavailable", HTTPStatus.SERVICE_UNAVAILABLE), ConfigEntryNotReady),
+        (RequestError("too many", HTTPStatus.TOO_MANY_REQUESTS), ConfigEntryNotReady),
+        # Other HTTP errors stay permanent.
+        (RequestError("forbidden", HTTPStatus.FORBIDDEN), ConfigEntryError),
+        (RequestError("not found", HTTPStatus.NOT_FOUND), ConfigEntryError),
+    ],
+)
+def test_config_entry_error_mapping(err: Exception, expected: type[Exception]) -> None:
+    """Setup login errors map to the right Home Assistant config-entry error."""
+    assert isinstance(_config_entry_error(err), expected)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,17 @@
+"""Tests for manager.py."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from custom_components.zaptec.manager import ZaptecManager
+from custom_components.zaptec.zaptec import Zaptec
+
+
+def test_manager_init_creates_empty_statistics_coordinators(
+    hass: MagicMock, config_entry: Any
+) -> None:
+    """ZaptecManager starts with an empty statistics_coordinators dict."""
+    manager = ZaptecManager(hass, entry=config_entry, zaptec=MagicMock(spec=Zaptec))
+    assert manager.statistics_coordinators == {}

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,284 @@
+"""Tests for number.py."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+import pytest
+
+from custom_components.zaptec.coordinator import ZaptecUpdateCoordinator, ZaptecUpdateOptions
+from custom_components.zaptec.number import (
+    ZapNumberEntityDescription,
+    ZaptecAvailableCurrentNumber,
+    ZaptecHmiBrightness,
+    ZaptecNumber,
+    ZaptecSettingNumber,
+    ZaptecThreeToOnePhaseSwitchCurrent,
+)
+from custom_components.zaptec.zaptec import Charger, Installation
+
+
+@pytest.fixture
+def coordinator(hass: MagicMock, config_entry: Any) -> ZaptecUpdateCoordinator:
+    """Create a ZaptecUpdateCoordinator for testing."""
+    manager = MagicMock()
+    options = ZaptecUpdateOptions(
+        name="test",
+        update_interval=600,
+        charging_update_interval=None,
+        tracked_devices=set(),
+        poll_args={},
+        zaptec_object=None,
+    )
+    return ZaptecUpdateCoordinator(hass, entry=config_entry, manager=manager, options=options)
+
+
+def make_charger(data: dict[str, Any]) -> MagicMock:
+    """Create a MagicMock(spec=Charger) whose .get() reads from data."""
+    charger = MagicMock(spec=Charger)
+    charger.id = "charger1"
+    charger.qual_id = "Charger[charger1]"
+    charger.get.side_effect = data.get
+    return charger
+
+
+def make_installation(data: dict[str, Any]) -> MagicMock:
+    """Create a MagicMock(spec=Installation) whose .get() reads from data."""
+    installation = MagicMock(spec=Installation)
+    installation.id = "install1"
+    installation.qual_id = "Installation[install1]"
+    installation.get.side_effect = data.get
+    return installation
+
+
+def test_number_update_from_zaptec_sets_value(coordinator: ZaptecUpdateCoordinator) -> None:
+    """ZaptecNumber._update_from_zaptec reads the raw value for its key."""
+    installation = make_installation({"available_current": 16.0})
+    description = ZapNumberEntityDescription(key="available_current", cls=ZaptecNumber)
+    entity = ZaptecNumber(coordinator, installation, description, DeviceInfo())
+
+    entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_native_value == 16.0  # noqa: SLF001, PLR2004
+    assert entity._attr_available is True  # noqa: SLF001
+
+
+def test_available_current_post_init_uses_reported_max_current(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecAvailableCurrentNumber._post_init sets native_max_value from MaxCurrent."""
+    installation = make_installation({"MaxCurrent": 20})
+    description = ZapNumberEntityDescription(
+        key="available_current", native_max_value=0, cls=ZaptecAvailableCurrentNumber
+    )
+    entity = ZaptecAvailableCurrentNumber(coordinator, installation, description, DeviceInfo())
+
+    assert entity.entity_description.native_max_value == 20  # noqa: PLR2004
+
+
+def test_available_current_post_init_defaults_to_32(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecAvailableCurrentNumber._post_init defaults to 32A when MaxCurrent is absent."""
+    installation = make_installation({})
+    description = ZapNumberEntityDescription(
+        key="available_current", native_max_value=0, cls=ZaptecAvailableCurrentNumber
+    )
+    entity = ZaptecAvailableCurrentNumber(coordinator, installation, description, DeviceInfo())
+
+    assert entity.entity_description.native_max_value == 32  # noqa: PLR2004
+
+
+async def test_available_current_set_native_value_success(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_set_native_value sets the current limit and triggers a poll on success."""
+    installation = make_installation({})
+    installation.set_limit_current = AsyncMock()
+    description = ZapNumberEntityDescription(
+        key="available_current", cls=ZaptecAvailableCurrentNumber
+    )
+    entity = ZaptecAvailableCurrentNumber(coordinator, installation, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    await entity.async_set_native_value(10.0)
+
+    installation.set_limit_current.assert_awaited_once_with(availableCurrent=10.0)
+    entity.trigger_poll.assert_awaited_once()
+
+
+async def test_available_current_set_native_value_wraps_failure(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_set_native_value wraps a failure in HomeAssistantError and skips the poll."""
+    installation = make_installation({})
+    installation.set_limit_current = AsyncMock(side_effect=Exception("boom"))
+    description = ZapNumberEntityDescription(
+        key="available_current", cls=ZaptecAvailableCurrentNumber
+    )
+    entity = ZaptecAvailableCurrentNumber(coordinator, installation, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_native_value(10.0)
+
+    entity.trigger_poll.assert_not_called()
+
+
+async def test_three_to_one_phase_set_native_value_success(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_set_native_value sets the switch current and triggers a poll on success."""
+    installation = make_installation({})
+    installation.set_three_to_one_phase_switch_current = AsyncMock()
+    description = ZapNumberEntityDescription(
+        key="three_to_one_phase_switch_current", cls=ZaptecThreeToOnePhaseSwitchCurrent
+    )
+    entity = ZaptecThreeToOnePhaseSwitchCurrent(
+        coordinator, installation, description, DeviceInfo()
+    )
+    entity.trigger_poll = AsyncMock()
+
+    await entity.async_set_native_value(8.0)
+
+    installation.set_three_to_one_phase_switch_current.assert_awaited_once_with(8.0)
+    entity.trigger_poll.assert_awaited_once()
+
+
+async def test_three_to_one_phase_set_native_value_wraps_failure(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_set_native_value wraps a failure in HomeAssistantError and skips the poll."""
+    installation = make_installation({})
+    installation.set_three_to_one_phase_switch_current = AsyncMock(side_effect=Exception("boom"))
+    description = ZapNumberEntityDescription(
+        key="three_to_one_phase_switch_current", cls=ZaptecThreeToOnePhaseSwitchCurrent
+    )
+    entity = ZaptecThreeToOnePhaseSwitchCurrent(
+        coordinator, installation, description, DeviceInfo()
+    )
+    entity.trigger_poll = AsyncMock()
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_native_value(8.0)
+
+    entity.trigger_poll.assert_not_called()
+
+
+def test_setting_number_post_init_uses_reported_max_limit(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecSettingNumber._post_init sets native_max_value from ChargeCurrentInstallationMaxLimit."""
+    charger = make_charger({"ChargeCurrentInstallationMaxLimit": 25})
+    description = ZapNumberEntityDescription(
+        key="charger_max_current",
+        native_max_value=0,
+        setting="maxChargeCurrent",
+        cls=ZaptecSettingNumber,
+    )
+    entity = ZaptecSettingNumber(coordinator, charger, description, DeviceInfo())
+
+    assert entity.entity_description.native_max_value == 25  # noqa: PLR2004
+
+
+async def test_setting_number_missing_setting_raises_without_calling_api(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_set_native_value raises HomeAssistantError when no setting is configured."""
+    charger = make_charger({})
+    charger.set_settings = AsyncMock()
+    description = ZapNumberEntityDescription(
+        key="charger_max_current", setting=None, cls=ZaptecSettingNumber
+    )
+    entity = ZaptecSettingNumber(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_native_value(16.0)
+
+    charger.set_settings.assert_not_called()
+    entity.trigger_poll.assert_not_called()
+
+
+async def test_setting_number_set_native_value_success(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_set_native_value writes the configured setting and triggers a poll on success."""
+    charger = make_charger({})
+    charger.set_settings = AsyncMock()
+    description = ZapNumberEntityDescription(
+        key="charger_max_current", setting="maxChargeCurrent", cls=ZaptecSettingNumber
+    )
+    entity = ZaptecSettingNumber(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    await entity.async_set_native_value(16.0)
+
+    charger.set_settings.assert_awaited_once_with({"maxChargeCurrent": 16.0})
+    entity.trigger_poll.assert_awaited_once()
+
+
+async def test_setting_number_set_native_value_wraps_failure(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_set_native_value wraps a failure in HomeAssistantError and skips the poll."""
+    charger = make_charger({})
+    charger.set_settings = AsyncMock(side_effect=Exception("boom"))
+    description = ZapNumberEntityDescription(
+        key="charger_max_current", setting="maxChargeCurrent", cls=ZaptecSettingNumber
+    )
+    entity = ZaptecSettingNumber(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_native_value(16.0)
+
+    entity.trigger_poll.assert_not_called()
+
+
+def test_hmi_brightness_update_from_zaptec_scales_up(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecHmiBrightness._update_from_zaptec scales the 0-1 API value to a 0-100 percentage."""
+    charger = make_charger({"hmi_brightness": 0.55})
+    description = ZapNumberEntityDescription(key="hmi_brightness", cls=ZaptecHmiBrightness)
+    entity = ZaptecHmiBrightness(coordinator, charger, description, DeviceInfo())
+
+    entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_native_value == pytest.approx(55.0)  # noqa: SLF001
+
+
+async def test_hmi_brightness_set_native_value_scales_down(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_set_native_value scales the 0-100 percentage back to 0-1 and triggers a poll."""
+    charger = make_charger({})
+    charger.set_hmi_brightness = AsyncMock()
+    description = ZapNumberEntityDescription(key="hmi_brightness", cls=ZaptecHmiBrightness)
+    entity = ZaptecHmiBrightness(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    await entity.async_set_native_value(50.0)
+
+    charger.set_hmi_brightness.assert_awaited_once_with(0.5)
+    entity.trigger_poll.assert_awaited_once()
+
+
+async def test_hmi_brightness_set_native_value_wraps_failure(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_set_native_value wraps a failure in HomeAssistantError and skips the poll."""
+    charger = make_charger({})
+    charger.set_hmi_brightness = AsyncMock(side_effect=Exception("boom"))
+    description = ZapNumberEntityDescription(key="hmi_brightness", cls=ZaptecHmiBrightness)
+    entity = ZaptecHmiBrightness(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_native_value(50.0)
+
+    entity.trigger_poll.assert_not_called()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,159 @@
+"""Tests for sensor.py."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+from homeassistant.helpers.entity import DeviceInfo
+import pytest
+
+from custom_components.zaptec.coordinator import ZaptecUpdateCoordinator, ZaptecUpdateOptions
+from custom_components.zaptec.sensor import (
+    ZapSensorEntityDescription,
+    ZaptecChargeSensor,
+    ZaptecEnengySensor,
+    ZaptecSensor,
+    ZaptecSensorTranslate,
+)
+from custom_components.zaptec.zaptec import Charger
+
+
+@pytest.fixture
+def coordinator(hass: MagicMock, config_entry: Any) -> ZaptecUpdateCoordinator:
+    """Create a ZaptecUpdateCoordinator for testing."""
+    manager = MagicMock()
+    options = ZaptecUpdateOptions(
+        name="test",
+        update_interval=600,
+        charging_update_interval=None,
+        tracked_devices=set(),
+        poll_args={},
+        zaptec_object=None,
+    )
+    return ZaptecUpdateCoordinator(hass, entry=config_entry, manager=manager, options=options)
+
+
+def make_charger(data: dict[str, Any]) -> MagicMock:
+    """Create a MagicMock(spec=Charger) whose .get() reads from data."""
+    charger = MagicMock(spec=Charger)
+    charger.id = "charger1"
+    charger.qual_id = "Charger[charger1]"
+    charger.get.side_effect = data.get
+    return charger
+
+
+def test_sensor_update_from_zaptec_sets_value(coordinator: ZaptecUpdateCoordinator) -> None:
+    """ZaptecSensor._update_from_zaptec reads the raw value for its key."""
+    charger = make_charger({"total_charge_power": 1500.0})
+    description = ZapSensorEntityDescription(key="total_charge_power", cls=ZaptecSensor)
+    entity = ZaptecSensor(coordinator, charger, description, DeviceInfo())
+
+    entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_native_value == 1500.0  # noqa: SLF001, PLR2004
+    assert entity._attr_available is True  # noqa: SLF001
+
+
+def test_sensor_translate_post_init_lower_cases_options(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecSensorTranslate._post_init lower-cases entity_description.options."""
+    charger = make_charger({"device_type": "PRO"})
+    description = ZapSensorEntityDescription(
+        key="device_type", options=["Pro", "GO"], cls=ZaptecSensorTranslate
+    )
+    entity = ZaptecSensorTranslate(coordinator, charger, description, DeviceInfo())
+
+    assert entity.entity_description.options == ["pro", "go"]
+
+
+def test_sensor_translate_update_from_zaptec_lower_cases_value(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecSensorTranslate._update_from_zaptec lower-cases the retrieved value."""
+    charger = make_charger({"device_type": "PRO"})
+    description = ZapSensorEntityDescription(
+        key="device_type", options=["pro"], cls=ZaptecSensorTranslate
+    )
+    entity = ZaptecSensorTranslate(coordinator, charger, description, DeviceInfo())
+
+    entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_native_value == "pro"  # noqa: SLF001
+    assert entity._attr_available is True  # noqa: SLF001
+
+
+def test_charge_sensor_maps_known_mode_to_icon(coordinator: ZaptecUpdateCoordinator) -> None:
+    """ZaptecChargeSensor picks the icon matching a known charger_operation_mode."""
+    charger = make_charger({"charger_operation_mode": "Connected_Charging"})
+    description = ZapSensorEntityDescription(key="charger_operation_mode", cls=ZaptecChargeSensor)
+    entity = ZaptecChargeSensor(coordinator, charger, description, DeviceInfo())
+
+    entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_native_value == "connected_charging"  # noqa: SLF001
+    assert entity._attr_icon == "mdi:lightning-bolt"  # noqa: SLF001
+
+
+def test_charge_sensor_falls_back_to_unknown_icon(coordinator: ZaptecUpdateCoordinator) -> None:
+    """ZaptecChargeSensor falls back to the 'unknown' icon for an unmapped mode."""
+    charger = make_charger({"charger_operation_mode": "Something_Weird"})
+    description = ZapSensorEntityDescription(key="charger_operation_mode", cls=ZaptecChargeSensor)
+    entity = ZaptecChargeSensor(coordinator, charger, description, DeviceInfo())
+
+    entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_icon == "mdi:help-rhombus-outline"  # noqa: SLF001
+
+
+def test_energy_sensor_uses_meter_value_when_no_session(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecEnengySensor falls back to the meter reading when no session is present."""
+    charger = make_charger({"signed_meter_value": {"RD": [{"RV": 12.5}]}})
+    description = ZapSensorEntityDescription(key="signed_meter_value_kwh", cls=ZaptecEnengySensor)
+    entity = ZaptecEnengySensor(coordinator, charger, description, DeviceInfo())
+
+    entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_native_value == 12.5  # noqa: SLF001, PLR2004
+
+
+def test_energy_sensor_uses_session_value_when_larger(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecEnengySensor uses the session reading when it exceeds the meter reading."""
+    charger = make_charger(
+        {
+            "signed_meter_value": {"RD": [{"RV": 10.0}]},
+            "completed_session": {"SignedSession": {"RD": [{"RV": 20.0}]}},
+        }
+    )
+    description = ZapSensorEntityDescription(key="signed_meter_value_kwh", cls=ZaptecEnengySensor)
+    entity = ZaptecEnengySensor(coordinator, charger, description, DeviceInfo())
+
+    entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_native_value == 20.0  # noqa: SLF001, PLR2004
+
+
+def test_energy_sensor_ignores_non_dict_session(
+    coordinator: ZaptecUpdateCoordinator, caplog: pytest.LogCaptureFixture
+) -> None:
+    """ZaptecEnengySensor logs and defaults the session reading to 0.0 when it isn't a dict."""
+    charger = make_charger(
+        {
+            "signed_meter_value": {"RD": [{"RV": 10.0}]},
+            "completed_session": "not-a-dict",
+        }
+    )
+    description = ZapSensorEntityDescription(key="signed_meter_value_kwh", cls=ZaptecEnengySensor)
+    entity = ZaptecEnengySensor(coordinator, charger, description, DeviceInfo())
+
+    with caplog.at_level(logging.DEBUG):
+        entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_native_value == 10.0  # noqa: SLF001, PLR2004
+    assert "Incorrect typing for completed_session" in caplog.text

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,685 @@
+"""Tests for services.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.core import ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+import pytest
+import voluptuous as vol
+import yaml
+
+from custom_components.zaptec.const import DOMAIN
+import custom_components.zaptec.services as services_module
+from custom_components.zaptec.services import (
+    CHARGER_ID_SCHEMA,
+    LIMIT_CURRENT_SCHEMA,
+    SEND_COMMAND_SCHEMA,
+    async_setup_services,
+    async_unload_services,
+)
+from custom_components.zaptec.zaptec import Charger, Installation
+
+SERVICES_YAML_PATH = Path(services_module.__file__).with_name("services.yaml")
+
+
+def make_call(hass: MagicMock, data: dict[str, Any]) -> ServiceCall:
+    """Build a ServiceCall carrying the given data, bypassing schema validation."""
+    return ServiceCall(hass, DOMAIN, "test_service", data)
+
+
+def make_charger(uid: str = "charger1") -> MagicMock:
+    """Create a MagicMock(spec=Charger) with async command methods."""
+    charger = MagicMock(spec=Charger)
+    charger.id = uid
+    charger.command = AsyncMock()
+    charger.authorize_charge = AsyncMock()
+    return charger
+
+
+def make_installation(uid: str = "install1") -> MagicMock:
+    """Create a MagicMock(spec=Installation) with an async set_limit_current."""
+    installation = MagicMock(spec=Installation)
+    installation.id = uid
+    installation.set_limit_current = AsyncMock()
+    return installation
+
+
+@pytest.fixture
+def manager() -> MagicMock:
+    """A manager stub exposing plain dicts for `.zaptec` and `.device_coordinators`."""
+    mgr = MagicMock()
+    mgr.zaptec = {}
+    mgr.device_coordinators = {}
+    return mgr
+
+
+@pytest.fixture
+def fake_registries() -> SimpleNamespace:
+    """Patch er.async_get/dr.async_get with dict-backed fakes and expose the dicts."""
+    entities: dict[str, Any] = {}
+    devices: dict[str, Any] = {}
+
+    ent_reg = MagicMock()
+    ent_reg.async_get.side_effect = entities.get
+
+    dev_reg = MagicMock()
+    dev_reg.async_get.side_effect = devices.get
+
+    with (
+        patch("custom_components.zaptec.services.er.async_get", return_value=ent_reg),
+        patch("custom_components.zaptec.services.dr.async_get", return_value=dev_reg),
+    ):
+        yield SimpleNamespace(entities=entities, devices=devices)
+
+
+@pytest.fixture
+def add_charger(manager: MagicMock) -> Any:
+    """Register a charger + coordinator pair under a given uid in the manager stubs."""
+
+    def _add(uid: str = "charger1") -> tuple[MagicMock, MagicMock]:
+        charger = make_charger(uid)
+        coordinator = MagicMock()
+        coordinator.trigger_poll = AsyncMock()
+        manager.zaptec[uid] = charger
+        manager.device_coordinators[uid] = coordinator
+        return charger, coordinator
+
+    return _add
+
+
+@pytest.fixture
+def add_installation(manager: MagicMock) -> Any:
+    """Register an installation + coordinator pair under a given uid in the manager stubs."""
+
+    def _add(uid: str = "install1") -> tuple[MagicMock, MagicMock]:
+        installation = make_installation(uid)
+        coordinator = MagicMock()
+        coordinator.trigger_poll = AsyncMock()
+        manager.zaptec[uid] = installation
+        manager.device_coordinators[uid] = coordinator
+        return installation, coordinator
+
+    return _add
+
+
+@pytest.fixture
+async def handlers(hass: MagicMock, manager: MagicMock) -> dict[str, Any]:
+    """Register zaptec services and return {name: handler} for direct invocation."""
+    hass.services.has_service = MagicMock(return_value=False)
+    await async_setup_services(hass, manager)
+    return {call.args[1]: call.args[2] for call in hass.services.async_register.call_args_list}
+
+
+# ---------------------------------------------------------------------------
+# async_setup_services / async_unload_services
+# ---------------------------------------------------------------------------
+
+
+async def test_async_setup_services_registers_all_services(hass: MagicMock) -> None:
+    """All eight zaptec services get registered under the zaptec domain."""
+    manager = MagicMock()
+    hass.services.has_service = MagicMock(return_value=False)
+
+    await async_setup_services(hass, manager)
+
+    registered = {call.args[1] for call in hass.services.async_register.call_args_list}
+    assert registered == {
+        "stop_charging",
+        "resume_charging",
+        "authorize_charging",
+        "deauthorize_charging",
+        "restart_charger",
+        "upgrade_firmware",
+        "limit_current",
+        "send_command",
+    }
+    assert all(call.args[0] == DOMAIN for call in hass.services.async_register.call_args_list)
+
+
+async def test_async_setup_services_skips_already_registered(hass: MagicMock) -> None:
+    """A service that has_service reports as already present is not re-registered."""
+    manager = MagicMock()
+    hass.services.has_service = MagicMock(
+        side_effect=lambda _domain, name: name == "stop_charging"
+    )
+
+    await async_setup_services(hass, manager)
+
+    registered = {call.args[1] for call in hass.services.async_register.call_args_list}
+    assert "stop_charging" not in registered
+    assert "resume_charging" in registered
+
+
+async def test_async_unload_services_removes_all_domain_services(hass: MagicMock) -> None:
+    """All services under the zaptec domain get removed."""
+    hass.services.async_services.return_value = {
+        DOMAIN: {"stop_charging": None, "limit_current": None},
+        "other_domain": {"foo": None},
+    }
+
+    await async_unload_services(hass)
+
+    assert hass.services.async_remove.call_count == 2  # noqa: PLR2004
+    removed = {call.args[1] for call in hass.services.async_remove.call_args_list}
+    assert removed == {"stop_charging", "limit_current"}
+    assert all(call.args[0] == DOMAIN for call in hass.services.async_remove.call_args_list)
+
+
+# ---------------------------------------------------------------------------
+# iter_objects resolution / error paths (exercised through stop_charging)
+# ---------------------------------------------------------------------------
+
+
+async def test_resolves_via_legacy_charger_id(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """A bare charger_id resolves directly to the zaptec object."""
+    charger, coordinator = add_charger("charger1")
+
+    await handlers["stop_charging"](make_call(hass, {"charger_id": "charger1"}))
+
+    charger.command.assert_awaited_once_with("stop_charging_final")
+    coordinator.trigger_poll.assert_awaited_once()
+
+
+async def test_resolves_via_device_id(
+    hass: MagicMock,
+    manager: MagicMock,
+    add_charger: Any,
+    handlers: dict[str, Any],
+    fake_registries: SimpleNamespace,
+) -> None:
+    """A device_id resolves through the device registry's zaptec identifier."""
+    charger, coordinator = add_charger("charger1")
+    fake_registries.devices["device1"] = SimpleNamespace(
+        identifiers={(DOMAIN, "charger1")}, name="Device 1"
+    )
+
+    await handlers["stop_charging"](make_call(hass, {"device_id": "device1"}))
+
+    charger.command.assert_awaited_once_with("stop_charging_final")
+    coordinator.trigger_poll.assert_awaited_once()
+
+
+async def test_resolves_via_entity_id(
+    hass: MagicMock,
+    manager: MagicMock,
+    add_charger: Any,
+    handlers: dict[str, Any],
+    fake_registries: SimpleNamespace,
+) -> None:
+    """An entity_id resolves through the entity registry's device, then the device registry."""
+    charger, coordinator = add_charger("charger1")
+    fake_registries.entities["sensor.foo"] = SimpleNamespace(device_id="device1")
+    fake_registries.devices["device1"] = SimpleNamespace(
+        identifiers={(DOMAIN, "charger1")}, name="Device 1"
+    )
+
+    await handlers["stop_charging"](make_call(hass, {"entity_id": "sensor.foo"}))
+
+    charger.command.assert_awaited_once_with("stop_charging_final")
+    coordinator.trigger_poll.assert_awaited_once()
+
+
+async def test_entity_id_not_found_raises(
+    hass: MagicMock, handlers: dict[str, Any], fake_registries: SimpleNamespace
+) -> None:
+    """An unknown entity_id raises a HomeAssistantError."""
+    with pytest.raises(HomeAssistantError, match="Unable to find entity"):
+        await handlers["stop_charging"](make_call(hass, {"entity_id": "sensor.missing"}))
+
+
+async def test_entity_without_device_raises(
+    hass: MagicMock, handlers: dict[str, Any], fake_registries: SimpleNamespace
+) -> None:
+    """An entity with no device_id raises a HomeAssistantError."""
+    fake_registries.entities["sensor.foo"] = SimpleNamespace(device_id=None)
+
+    with pytest.raises(HomeAssistantError, match="doesn't have a device"):
+        await handlers["stop_charging"](make_call(hass, {"entity_id": "sensor.foo"}))
+
+
+async def test_device_id_not_found_raises(
+    hass: MagicMock, handlers: dict[str, Any], fake_registries: SimpleNamespace
+) -> None:
+    """An unknown device_id raises a HomeAssistantError."""
+    with pytest.raises(HomeAssistantError, match="Unable to find device"):
+        await handlers["stop_charging"](make_call(hass, {"device_id": "device_missing"}))
+
+
+async def test_device_without_identifiers_raises(
+    hass: MagicMock, handlers: dict[str, Any], fake_registries: SimpleNamespace
+) -> None:
+    """A device with no identifiers raises a HomeAssistantError."""
+    fake_registries.devices["device1"] = SimpleNamespace(identifiers=set(), name="Device 1")
+
+    with pytest.raises(HomeAssistantError, match="Unable to find identifiers"):
+        await handlers["stop_charging"](make_call(hass, {"device_id": "device1"}))
+
+
+async def test_device_with_non_zaptec_identifier_raises(
+    hass: MagicMock, handlers: dict[str, Any], fake_registries: SimpleNamespace
+) -> None:
+    """A device tied to a non-zaptec identifier domain raises a HomeAssistantError."""
+    fake_registries.devices["device1"] = SimpleNamespace(
+        identifiers={("other_domain", "foo")}, name="Device 1"
+    )
+
+    with pytest.raises(HomeAssistantError, match="Non-zaptec device specified"):
+        await handlers["stop_charging"](make_call(hass, {"device_id": "device1"}))
+
+
+async def test_no_ids_specified_raises_with_missing_field(
+    hass: MagicMock, handlers: dict[str, Any]
+) -> None:
+    """Calling a handler with none of charger_id/device_id/entity_id set names the missing field."""
+    with pytest.raises(HomeAssistantError, match="Missing field 'charger_id'"):
+        await handlers["stop_charging"](make_call(hass, {}))
+
+
+async def test_unknown_zaptec_object_raises(hass: MagicMock, handlers: dict[str, Any]) -> None:
+    """A uid with no matching zaptec object raises a HomeAssistantError."""
+    with pytest.raises(HomeAssistantError, match="Unable to find zaptec object"):
+        await handlers["stop_charging"](make_call(hass, {"charger_id": "charger_missing"}))
+
+
+async def test_wrong_object_type_raises(
+    hass: MagicMock, manager: MagicMock, add_installation: Any, handlers: dict[str, Any]
+) -> None:
+    """A uid resolving to the wrong zaptec object type raises a HomeAssistantError."""
+    add_installation("install1")
+
+    with pytest.raises(HomeAssistantError, match="is not a Charger"):
+        await handlers["stop_charging"](make_call(hass, {"charger_id": "install1"}))
+
+
+async def test_object_without_coordinator_raises(
+    hass: MagicMock, manager: MagicMock, handlers: dict[str, Any]
+) -> None:
+    """A resolved zaptec object with no matching coordinator raises a HomeAssistantError."""
+    manager.zaptec["charger1"] = make_charger("charger1")
+
+    with pytest.raises(HomeAssistantError, match="is not available"):
+        await handlers["stop_charging"](make_call(hass, {"charger_id": "charger1"}))
+
+
+async def test_multiple_chargers_in_one_call_are_all_processed(
+    hass: MagicMock,
+    manager: MagicMock,
+    add_charger: Any,
+    handlers: dict[str, Any],
+    fake_registries: SimpleNamespace,
+) -> None:
+    """A single call mixing a legacy charger_id and a device_id targets both chargers."""
+    charger1, coordinator1 = add_charger("charger1")
+    charger2, coordinator2 = add_charger("charger2")
+    fake_registries.devices["device2"] = SimpleNamespace(
+        identifiers={(DOMAIN, "charger2")}, name="Device 2"
+    )
+
+    await handlers["stop_charging"](
+        make_call(hass, {"charger_id": "charger1", "device_id": ["device2"]})
+    )
+
+    charger1.command.assert_awaited_once_with("stop_charging_final")
+    coordinator1.trigger_poll.assert_awaited_once()
+    charger2.command.assert_awaited_once_with("stop_charging_final")
+    coordinator2.trigger_poll.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Individual service handlers
+# ---------------------------------------------------------------------------
+
+
+async def test_stop_charging_wraps_command_failure(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """A command failure is wrapped in HomeAssistantError and no poll is triggered."""
+    charger, coordinator = add_charger("charger1")
+    charger.command.side_effect = Exception("boom")
+
+    with pytest.raises(HomeAssistantError, match="stop_charging_final"):
+        await handlers["stop_charging"](make_call(hass, {"charger_id": "charger1"}))
+
+    coordinator.trigger_poll.assert_not_awaited()
+
+
+async def test_resume_charging_sends_command(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """resume_charging sends the resume_charging command and polls."""
+    charger, coordinator = add_charger("charger1")
+
+    await handlers["resume_charging"](make_call(hass, {"charger_id": "charger1"}))
+
+    charger.command.assert_awaited_once_with("resume_charging")
+    coordinator.trigger_poll.assert_awaited_once()
+
+
+async def test_resume_charging_wraps_command_failure(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """A command failure is wrapped in HomeAssistantError and no poll is triggered."""
+    charger, coordinator = add_charger("charger1")
+    charger.command.side_effect = Exception("boom")
+
+    with pytest.raises(HomeAssistantError, match="resume_charging"):
+        await handlers["resume_charging"](make_call(hass, {"charger_id": "charger1"}))
+
+    coordinator.trigger_poll.assert_not_awaited()
+
+
+async def test_authorize_charging_calls_authorize_charge(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """authorize_charging calls authorize_charge and polls."""
+    charger, coordinator = add_charger("charger1")
+
+    await handlers["authorize_charging"](make_call(hass, {"charger_id": "charger1"}))
+
+    charger.authorize_charge.assert_awaited_once()
+    coordinator.trigger_poll.assert_awaited_once()
+
+
+async def test_authorize_charging_wraps_failure(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """A authorize_charge failure is wrapped in HomeAssistantError."""
+    charger, coordinator = add_charger("charger1")
+    charger.authorize_charge.side_effect = Exception("boom")
+
+    with pytest.raises(HomeAssistantError, match="authorize_charge"):
+        await handlers["authorize_charging"](make_call(hass, {"charger_id": "charger1"}))
+
+    coordinator.trigger_poll.assert_not_awaited()
+
+
+async def test_deauthorize_charging_sends_command(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """deauthorize_charging sends the deauthorize_and_stop command and polls."""
+    charger, coordinator = add_charger("charger1")
+
+    await handlers["deauthorize_charging"](make_call(hass, {"charger_id": "charger1"}))
+
+    charger.command.assert_awaited_once_with("deauthorize_and_stop")
+    coordinator.trigger_poll.assert_awaited_once()
+
+
+async def test_deauthorize_charging_wraps_command_failure(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """A command failure is wrapped in HomeAssistantError and no poll is triggered."""
+    charger, coordinator = add_charger("charger1")
+    charger.command.side_effect = Exception("boom")
+
+    with pytest.raises(HomeAssistantError, match="deauthorize_and_stop"):
+        await handlers["deauthorize_charging"](make_call(hass, {"charger_id": "charger1"}))
+
+    coordinator.trigger_poll.assert_not_awaited()
+
+
+async def test_restart_charger_sends_command(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """restart_charger sends the restart_charger command and polls."""
+    charger, coordinator = add_charger("charger1")
+
+    await handlers["restart_charger"](make_call(hass, {"charger_id": "charger1"}))
+
+    charger.command.assert_awaited_once_with("restart_charger")
+    coordinator.trigger_poll.assert_awaited_once()
+
+
+async def test_restart_charger_wraps_command_failure(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """A command failure is wrapped in HomeAssistantError and no poll is triggered."""
+    charger, coordinator = add_charger("charger1")
+    charger.command.side_effect = Exception("boom")
+
+    with pytest.raises(HomeAssistantError, match="restart_charger"):
+        await handlers["restart_charger"](make_call(hass, {"charger_id": "charger1"}))
+
+    coordinator.trigger_poll.assert_not_awaited()
+
+
+async def test_upgrade_firmware_sends_command(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """upgrade_firmware sends the upgrade_firmware command and polls."""
+    charger, coordinator = add_charger("charger1")
+
+    await handlers["upgrade_firmware"](make_call(hass, {"charger_id": "charger1"}))
+
+    charger.command.assert_awaited_once_with("upgrade_firmware")
+    coordinator.trigger_poll.assert_awaited_once()
+
+
+async def test_upgrade_firmware_wraps_command_failure(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """A command failure is wrapped in HomeAssistantError and no poll is triggered."""
+    charger, coordinator = add_charger("charger1")
+    charger.command.side_effect = Exception("boom")
+
+    with pytest.raises(HomeAssistantError, match="upgrade_firmware"):
+        await handlers["upgrade_firmware"](make_call(hass, {"charger_id": "charger1"}))
+
+    coordinator.trigger_poll.assert_not_awaited()
+
+
+async def test_limit_current_with_available_current_only(
+    hass: MagicMock, manager: MagicMock, add_installation: Any, handlers: dict[str, Any]
+) -> None:
+    """Only availableCurrent is passed through when available_current is set."""
+    installation, coordinator = add_installation("install1")
+
+    await handlers["limit_current"](
+        make_call(hass, {"installation_id": "install1", "available_current": 16})
+    )
+
+    installation.set_limit_current.assert_awaited_once_with(availableCurrent=16)
+    coordinator.trigger_poll.assert_awaited_once()
+
+
+async def test_limit_current_with_all_phases(
+    hass: MagicMock, manager: MagicMock, add_installation: Any, handlers: dict[str, Any]
+) -> None:
+    """All three phase kwargs are passed through when the phase fields are set."""
+    installation, coordinator = add_installation("install1")
+
+    await handlers["limit_current"](
+        make_call(
+            hass,
+            {
+                "installation_id": "install1",
+                "available_current_phase1": 10,
+                "available_current_phase2": 11,
+                "available_current_phase3": 12,
+            },
+        )
+    )
+
+    installation.set_limit_current.assert_awaited_once_with(
+        availableCurrentPhase1=10, availableCurrentPhase2=11, availableCurrentPhase3=12
+    )
+    coordinator.trigger_poll.assert_awaited_once()
+
+
+async def test_limit_current_wraps_failure(
+    hass: MagicMock, manager: MagicMock, add_installation: Any, handlers: dict[str, Any]
+) -> None:
+    """A set_limit_current failure is wrapped in HomeAssistantError and skips the poll."""
+    installation, coordinator = add_installation("install1")
+    installation.set_limit_current.side_effect = Exception("boom")
+
+    with pytest.raises(HomeAssistantError, match="Limit current failed"):
+        await handlers["limit_current"](
+            make_call(hass, {"installation_id": "install1", "available_current": 16})
+        )
+
+    coordinator.trigger_poll.assert_not_awaited()
+
+
+async def test_send_command_with_string_command(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """send_command forwards a string command and polls."""
+    charger, coordinator = add_charger("charger1")
+
+    await handlers["send_command"](
+        make_call(hass, {"charger_id": "charger1", "command": "StopChargingFinal"})
+    )
+
+    charger.command.assert_awaited_once_with("StopChargingFinal")
+    coordinator.trigger_poll.assert_awaited_once()
+
+
+async def test_send_command_with_integer_command(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """send_command forwards an integer command."""
+    charger, _coordinator = add_charger("charger1")
+
+    await handlers["send_command"](make_call(hass, {"charger_id": "charger1", "command": 507}))
+
+    charger.command.assert_awaited_once_with(507)
+
+
+async def test_send_command_missing_command_raises(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """send_command without a command value raises before calling the charger."""
+    charger, _coordinator = add_charger("charger1")
+
+    with pytest.raises(HomeAssistantError, match="No Command received"):
+        await handlers["send_command"](make_call(hass, {"charger_id": "charger1"}))
+
+    charger.command.assert_not_awaited()
+
+
+async def test_send_command_wraps_failure(
+    hass: MagicMock, manager: MagicMock, add_charger: Any, handlers: dict[str, Any]
+) -> None:
+    """A command failure is wrapped in HomeAssistantError and skips the poll."""
+    charger, coordinator = add_charger("charger1")
+    charger.command.side_effect = Exception("boom")
+
+    with pytest.raises(HomeAssistantError, match="'StopChargingFinal' failed"):
+        await handlers["send_command"](
+            make_call(hass, {"charger_id": "charger1", "command": "StopChargingFinal"})
+        )
+
+    coordinator.trigger_poll.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_charger_id_schema_requires_one_of_the_id_fields() -> None:
+    """CHARGER_ID_SCHEMA rejects data with none of charger_id/device_id/entity_id."""
+    with pytest.raises(vol.Invalid, match="At leas one of"):
+        CHARGER_ID_SCHEMA({})
+
+
+def test_charger_id_schema_accepts_entity_id() -> None:
+    """CHARGER_ID_SCHEMA accepts a bare entity_id and normalizes it to a list."""
+    result = CHARGER_ID_SCHEMA({"entity_id": "sensor.foo"})
+    assert result["entity_id"] == ["sensor.foo"]
+
+
+def test_limit_current_schema_requires_current_value() -> None:
+    """LIMIT_CURRENT_SCHEMA rejects data with neither available_current nor all three phases."""
+    with pytest.raises(vol.Invalid, match="Either 'available_current'"):
+        LIMIT_CURRENT_SCHEMA({"installation_id": "x"})
+
+
+def test_limit_current_schema_accepts_available_current() -> None:
+    """LIMIT_CURRENT_SCHEMA accepts a bare available_current."""
+    result = LIMIT_CURRENT_SCHEMA({"installation_id": "x", "available_current": 16})
+    assert result["available_current"] == 16  # noqa: PLR2004
+
+
+def test_limit_current_schema_accepts_all_three_phases() -> None:
+    """LIMIT_CURRENT_SCHEMA accepts all three phase fields together."""
+    result = LIMIT_CURRENT_SCHEMA(
+        {
+            "installation_id": "x",
+            "available_current_phase1": 1,
+            "available_current_phase2": 2,
+            "available_current_phase3": 3,
+        }
+    )
+    assert result["available_current_phase3"] == 3  # noqa: PLR2004
+
+
+def test_limit_current_schema_rejects_partial_phases() -> None:
+    """LIMIT_CURRENT_SCHEMA rejects only two of the three phase fields."""
+    with pytest.raises(vol.Invalid, match="Either 'available_current'"):
+        LIMIT_CURRENT_SCHEMA(
+            {
+                "installation_id": "x",
+                "available_current_phase1": 1,
+                "available_current_phase2": 2,
+            }
+        )
+
+
+def test_limit_current_schema_rejects_current_and_phases_together() -> None:
+    """LIMIT_CURRENT_SCHEMA rejects mixing available_current with the phase fields."""
+    with pytest.raises(vol.Invalid, match="Either 'available_current'"):
+        LIMIT_CURRENT_SCHEMA(
+            {
+                "installation_id": "x",
+                "available_current": 16,
+                "available_current_phase1": 1,
+                "available_current_phase2": 2,
+                "available_current_phase3": 3,
+            }
+        )
+
+
+def test_send_command_schema_accepts_string_and_int_commands() -> None:
+    """SEND_COMMAND_SCHEMA accepts both string and integer commands."""
+    assert (
+        SEND_COMMAND_SCHEMA({"charger_id": "x", "command": "StopChargingFinal"})["command"]
+        == "StopChargingFinal"
+    )
+    assert SEND_COMMAND_SCHEMA({"charger_id": "x", "command": 5})["command"] == 5  # noqa: PLR2004
+
+
+def test_send_command_schema_requires_command() -> None:
+    """SEND_COMMAND_SCHEMA rejects data missing the command field."""
+    with pytest.raises(vol.Invalid, match="required key not provided"):
+        SEND_COMMAND_SCHEMA({"charger_id": "x"})
+
+
+# ---------------------------------------------------------------------------
+# services.yaml consistency
+# ---------------------------------------------------------------------------
+
+
+async def test_services_yaml_keys_match_registered_service_names(hass: MagicMock) -> None:
+    """services.yaml documents exactly the services async_setup_services registers.
+
+    A key mismatch here (e.g. a typo) means HA's UI silently falls back to an
+    undocumented, field-less form for the real service, while the yaml entry
+    documents a service that doesn't exist.
+    """
+    manager = MagicMock()
+    hass.services.has_service = MagicMock(return_value=False)
+    await async_setup_services(hass, manager)
+    registered = {call.args[1] for call in hass.services.async_register.call_args_list}
+
+    documented = set(yaml.safe_load(SERVICES_YAML_PATH.read_text()))
+
+    assert documented == registered

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -289,3 +289,57 @@ async def test_other_request_errors_raise_update_failed(
         )
         with pytest.raises(UpdateFailed):
             await coordinator._async_update_data()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_pages_through_multiple_results(hass: MagicMock, config_entry: Any) -> None:
+    """Cursor from page 1 is threaded into page 2's request; both pages' sessions are imported."""
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        side_effect=[
+            {
+                "Sessions": [
+                    {
+                        "Id": "s1",
+                        "EnergyDetails": [
+                            {"Timestamp": "2026-01-01T10:10:00+00:00", "Energy": 1.0}
+                        ],
+                    }
+                ],
+                "Cursor": "page2-cursor",
+                "HasMore": True,
+            },
+            {
+                "Sessions": [
+                    {
+                        "Id": "s2",
+                        "EnergyDetails": [
+                            {"Timestamp": "2026-01-01T12:10:00+00:00", "Energy": 2.0}
+                        ],
+                    }
+                ],
+                "Cursor": None,
+                "HasMore": False,
+            },
+        ]
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch("custom_components.zaptec.statistics.get_last_statistics", return_value={}),
+        patch("custom_components.zaptec.statistics.async_add_external_statistics") as mock_add,
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        await coordinator._async_update_data()  # noqa: SLF001
+
+    assert charger.get_archived_sessions.await_count == 2  # noqa: PLR2004
+    first_call, second_call = charger.get_archived_sessions.await_args_list
+    assert "cursor" not in first_call.kwargs or first_call.kwargs["cursor"] is None
+    assert second_call.kwargs["cursor"] == "page2-cursor"
+
+    _hass_arg, _metadata, statistics = mock_add.call_args[0]
+    assert len(statistics) == 2  # noqa: PLR2004
+    assert [s["sum"] for s in statistics] == [1.0, 3.0]

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -32,9 +32,9 @@ def test_single_session_within_one_hour() -> None:
     result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
 
     assert len(result) == 1
-    assert result[0].start == datetime(2026, 1, 1, 10, tzinfo=timezone.utc)  # noqa: UP017
-    assert result[0].state == 2.5  # noqa: PLR2004
-    assert result[0].sum == 2.5  # noqa: PLR2004
+    assert result[0]["start"] == datetime(2026, 1, 1, 10, tzinfo=timezone.utc)  # noqa: UP017
+    assert result[0]["state"] == 2.5  # noqa: PLR2004
+    assert result[0]["sum"] == 2.5  # noqa: PLR2004
 
 
 def test_session_spanning_two_hours_creates_two_buckets() -> None:
@@ -49,14 +49,14 @@ def test_session_spanning_two_hours_creates_two_buckets() -> None:
 
     result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
 
-    assert [r.start for r in result] == [
+    assert [r["start"] for r in result] == [
         datetime(2026, 1, 1, 10, tzinfo=timezone.utc),  # noqa: UP017
         datetime(2026, 1, 1, 11, tzinfo=timezone.utc),  # noqa: UP017
     ]
-    assert result[0].state == 1.0
-    assert result[0].sum == 1.0
-    assert result[1].state == 0.6000000000000001  # noqa: PLR2004
-    assert result[1].sum == 1.6  # noqa: PLR2004
+    assert result[0]["state"] == 1.0
+    assert result[0]["sum"] == 1.0
+    assert result[1]["state"] == 0.6000000000000001  # noqa: PLR2004
+    assert result[1]["sum"] == 1.6  # noqa: PLR2004
 
 
 def test_after_cutoff_excludes_already_imported_points() -> None:
@@ -73,9 +73,9 @@ def test_after_cutoff_excludes_already_imported_points() -> None:
     result = bucket_sessions_hourly([session], after=cutoff, running_sum=5.0)
 
     assert len(result) == 1
-    assert result[0].start == datetime(2026, 1, 1, 11, tzinfo=timezone.utc)  # noqa: UP017
-    assert result[0].state == 1.0
-    assert result[0].sum == 6.0  # noqa: PLR2004
+    assert result[0]["start"] == datetime(2026, 1, 1, 11, tzinfo=timezone.utc)  # noqa: UP017
+    assert result[0]["state"] == 1.0
+    assert result[0]["sum"] == 6.0  # noqa: PLR2004
 
 
 def test_session_without_energy_details_falls_back_to_total() -> None:
@@ -90,8 +90,8 @@ def test_session_without_energy_details_falls_back_to_total() -> None:
     result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
 
     assert len(result) == 1
-    assert result[0].start == datetime(2026, 1, 1, 10, tzinfo=timezone.utc)  # noqa: UP017
-    assert result[0].state == 3.0  # noqa: PLR2004
+    assert result[0]["start"] == datetime(2026, 1, 1, 10, tzinfo=timezone.utc)  # noqa: UP017
+    assert result[0]["state"] == 3.0  # noqa: PLR2004
 
 
 def test_running_sum_carries_across_sessions() -> None:
@@ -101,7 +101,7 @@ def test_running_sum_carries_across_sessions() -> None:
 
     result = bucket_sessions_hourly([session1, session2], after=None, running_sum=10.0)
 
-    assert [r.sum for r in result] == [11.0, 13.0]
+    assert [r["sum"] for r in result] == [11.0, 13.0]
 
 
 def test_voided_and_aborted_sessions_are_skipped() -> None:
@@ -115,5 +115,5 @@ def test_voided_and_aborted_sessions_are_skipped() -> None:
     result = bucket_sessions_hourly([voided, aborted, real], after=None, running_sum=0.0)
 
     assert len(result) == 1
-    assert result[0].start == datetime(2026, 1, 1, 12, tzinfo=timezone.utc)  # noqa: UP017
-    assert result[0].state == 3.0  # noqa: PLR2004
+    assert result[0]["start"] == datetime(2026, 1, 1, 12, tzinfo=timezone.utc)  # noqa: UP017
+    assert result[0]["state"] == 3.0  # noqa: PLR2004

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -36,7 +36,12 @@ def _session(
 
 
 def test_single_session_within_one_hour() -> None:
-    """A session with all points inside one hour produces a single bucket."""
+    """A session with all points inside one hour produces a single bucket.
+
+    Each point's `energy` is already the delta for that interval (confirmed
+    live against OCMF-signed meter readings), so same-hour points sum
+    directly rather than differencing against the previous point.
+    """
     session = _session(
         "s1", [("2026-01-01T10:10:00+00:00", 1.0), ("2026-01-01T10:40:00+00:00", 2.5)]
     )
@@ -45,8 +50,8 @@ def test_single_session_within_one_hour() -> None:
 
     assert len(result) == 1
     assert result[0]["start"] == datetime(2026, 1, 1, 10, tzinfo=timezone.utc)  # noqa: UP017
-    assert result[0]["state"] == 2.5  # noqa: PLR2004
-    assert result[0]["sum"] == 2.5  # noqa: PLR2004
+    assert result[0]["state"] == 3.5  # noqa: PLR2004
+    assert result[0]["sum"] == 3.5  # noqa: PLR2004
 
 
 def test_session_spanning_two_hours_creates_two_buckets() -> None:
@@ -67,8 +72,8 @@ def test_session_spanning_two_hours_creates_two_buckets() -> None:
     ]
     assert result[0]["state"] == 1.0
     assert result[0]["sum"] == 1.0
-    assert result[1]["state"] == 0.6000000000000001  # noqa: PLR2004
-    assert result[1]["sum"] == 1.6  # noqa: PLR2004
+    assert result[1]["state"] == 1.6  # noqa: PLR2004
+    assert result[1]["sum"] == 2.6  # noqa: PLR2004
 
 
 def test_after_cutoff_excludes_already_imported_points() -> None:
@@ -86,8 +91,8 @@ def test_after_cutoff_excludes_already_imported_points() -> None:
 
     assert len(result) == 1
     assert result[0]["start"] == datetime(2026, 1, 1, 11, tzinfo=timezone.utc)  # noqa: UP017
-    assert result[0]["state"] == 1.0
-    assert result[0]["sum"] == 6.0  # noqa: PLR2004
+    assert result[0]["state"] == 2.0  # noqa: PLR2004
+    assert result[0]["sum"] == 7.0  # noqa: PLR2004
 
 
 def test_after_cutoff_excludes_entire_last_imported_hour() -> None:
@@ -105,8 +110,8 @@ def test_after_cutoff_excludes_entire_last_imported_hour() -> None:
 
     assert len(result) == 1
     assert result[0]["start"] == datetime(2026, 1, 1, 12, tzinfo=timezone.utc)  # noqa: UP017
-    assert result[0]["state"] == 0.5  # noqa: PLR2004
-    assert result[0]["sum"] == 3.5  # noqa: PLR2004
+    assert result[0]["state"] == 1.5  # noqa: PLR2004
+    assert result[0]["sum"] == 4.5  # noqa: PLR2004
 
 
 def test_session_without_energy_details_falls_back_to_total() -> None:

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -26,12 +26,12 @@ def _session(
     end: str | None = None,
     energy: float = 0.0,
 ) -> dict:
-    """Build a raw archived-session dict with the given EnergyDetails points."""
+    """Build a raw archived-session dict with the given energyDetails points."""
     return {
-        "Id": session_id,
-        "EndDateTime": end,
-        "Energy": energy,
-        "EnergyDetails": [{"Timestamp": ts, "Energy": e} for ts, e in points],
+        "id": session_id,
+        "endDateTime": end,
+        "energy": energy,
+        "energyDetails": [{"timestamp": ts, "energy": e} for ts, e in points],
     }
 
 
@@ -110,12 +110,12 @@ def test_after_cutoff_excludes_entire_last_imported_hour() -> None:
 
 
 def test_session_without_energy_details_falls_back_to_total() -> None:
-    """A legacy session with no EnergyDetails uses its total Energy at EndDateTime."""
+    """A legacy session with no energyDetails uses its total energy at endDateTime."""
     session = {
-        "Id": "s1",
-        "EndDateTime": "2026-01-01T10:45:00+00:00",
-        "Energy": 3.0,
-        "EnergyDetails": [],
+        "id": "s1",
+        "endDateTime": "2026-01-01T10:45:00+00:00",
+        "energy": 3.0,
+        "energyDetails": [],
     }
 
     result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
@@ -138,9 +138,9 @@ def test_running_sum_carries_across_sessions() -> None:
 def test_voided_and_aborted_sessions_are_skipped() -> None:
     """Voided/aborted sessions have no meaningful energy and must not be counted."""
     voided = _session("s1", [("2026-01-01T10:10:00+00:00", 1.0)])
-    voided["Voided"] = True
+    voided["voided"] = True
     aborted = _session("s2", [("2026-01-01T11:10:00+00:00", 2.0)])
-    aborted["Aborted"] = True
+    aborted["aborted"] = True
     real = _session("s3", [("2026-01-01T12:10:00+00:00", 3.0)])
 
     result = bucket_sessions_hourly([voided, aborted, real], after=None, running_sum=0.0)
@@ -148,6 +148,25 @@ def test_voided_and_aborted_sessions_are_skipped() -> None:
     assert len(result) == 1
     assert result[0]["start"] == datetime(2026, 1, 1, 12, tzinfo=timezone.utc)  # noqa: UP017
     assert result[0]["state"] == 3.0  # noqa: PLR2004
+
+
+def test_bucket_sessions_hourly_uses_camelcase_keys() -> None:
+    """Regression test: /api/sessions/archived genuinely returns camelCase (confirmed live 2026-07-12), unlike every other Zaptec endpoint's PascalCase - this must keep working."""
+    session = {
+        "id": "b9b00000-0000-0000-0000-000000000000",
+        "chargerId": "c1",
+        "startDateTime": "2026-01-01T09:00:00+00:00",
+        "endDateTime": "2026-01-01T10:00:00+00:00",
+        "energy": 1.5,
+        "energyDetails": [{"timestamp": "2026-01-01T09:30:00+00:00", "energy": 1.5}],
+        "voided": False,
+        "aborted": False,
+    }
+
+    result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
+
+    assert len(result) == 1
+    assert result[0]["state"] == 1.5  # noqa: PLR2004
 
 
 def _make_charger(charger_id: str = "charger-1") -> MagicMock:
@@ -173,14 +192,14 @@ async def test_first_run_backfills_from_zero_sum(hass: MagicMock, config_entry: 
     charger = _make_charger()
     charger.get_archived_sessions = AsyncMock(
         return_value={
-            "Sessions": [
+            "sessions": [
                 {
-                    "Id": "s1",
-                    "EnergyDetails": [{"Timestamp": "2026-01-01T10:10:00+00:00", "Energy": 2.0}],
+                    "id": "s1",
+                    "energyDetails": [{"timestamp": "2026-01-01T10:10:00+00:00", "energy": 2.0}],
                 }
             ],
-            "Cursor": None,
-            "HasMore": False,
+            "cursor": None,
+            "hasMore": False,
         }
     )
     coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
@@ -213,7 +232,7 @@ async def test_no_new_sessions_does_not_call_add_statistics(
     """If there's nothing new to import, async_add_external_statistics is not called."""
     charger = _make_charger()
     charger.get_archived_sessions = AsyncMock(
-        return_value={"Sessions": [], "Cursor": None, "HasMore": False}
+        return_value={"sessions": [], "cursor": None, "hasMore": False}
     )
     coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
 
@@ -235,7 +254,7 @@ async def test_resumes_from_last_statistics(hass: MagicMock, config_entry: Any) 
     """A prior statistics entry sets the resume point and running sum."""
     charger = _make_charger()
     charger.get_archived_sessions = AsyncMock(
-        return_value={"Sessions": [], "Cursor": None, "HasMore": False}
+        return_value={"sessions": [], "cursor": None, "hasMore": False}
     )
     coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
     last_start = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
@@ -317,28 +336,28 @@ async def test_pages_through_multiple_results(hass: MagicMock, config_entry: Any
     charger.get_archived_sessions = AsyncMock(
         side_effect=[
             {
-                "Sessions": [
+                "sessions": [
                     {
-                        "Id": "s1",
-                        "EnergyDetails": [
-                            {"Timestamp": "2026-01-01T10:10:00+00:00", "Energy": 1.0}
+                        "id": "s1",
+                        "energyDetails": [
+                            {"timestamp": "2026-01-01T10:10:00+00:00", "energy": 1.0}
                         ],
                     }
                 ],
-                "Cursor": "page2-cursor",
-                "HasMore": True,
+                "cursor": "page2-cursor",
+                "hasMore": True,
             },
             {
-                "Sessions": [
+                "sessions": [
                     {
-                        "Id": "s2",
-                        "EnergyDetails": [
-                            {"Timestamp": "2026-01-01T12:10:00+00:00", "Energy": 2.0}
+                        "id": "s2",
+                        "energyDetails": [
+                            {"timestamp": "2026-01-01T12:10:00+00:00", "energy": 2.0}
                         ],
                     }
                 ],
-                "Cursor": None,
-                "HasMore": False,
+                "cursor": None,
+                "hasMore": False,
             },
         ]
     )

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from custom_components.zaptec.statistics import bucket_sessions_hourly
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from homeassistant.util import dt as dt_util
+import pytest
+
+from custom_components.zaptec.statistics import (
+    ZaptecStatisticsCoordinator,
+    bucket_sessions_hourly,
+)
+from custom_components.zaptec.zaptec import Charger
+from custom_components.zaptec.zaptec.exceptions import RequestError
 
 
 def _session(
@@ -117,3 +129,163 @@ def test_voided_and_aborted_sessions_are_skipped() -> None:
     assert len(result) == 1
     assert result[0]["start"] == datetime(2026, 1, 1, 12, tzinfo=timezone.utc)  # noqa: UP017
     assert result[0]["state"] == 3.0  # noqa: PLR2004
+
+
+def _make_charger(charger_id: str = "charger-1") -> MagicMock:
+    """A fake Charger exposing only what the coordinator touches."""
+    charger = MagicMock(spec=Charger)
+    charger.id = charger_id
+    charger.name = "My Charger"
+    charger.qual_id = f"Charger[{charger_id}]"
+    return charger
+
+
+@pytest.mark.asyncio
+async def test_statistic_id_derived_from_charger_id(hass: MagicMock, config_entry: Any) -> None:
+    """The statistic_id is stable and derived from the charger's id."""
+    charger = _make_charger("abc-123")
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+    assert coordinator.statistic_id == "zaptec:energy_abc123"
+
+
+@pytest.mark.asyncio
+async def test_first_run_backfills_from_zero_sum(hass: MagicMock, config_entry: Any) -> None:
+    """With no prior statistics, the coordinator starts from sum=0 and pages through results."""
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        return_value={
+            "Sessions": [
+                {
+                    "Id": "s1",
+                    "EnergyDetails": [{"Timestamp": "2026-01-01T10:10:00+00:00", "Energy": 2.0}],
+                }
+            ],
+            "Cursor": None,
+            "HasMore": False,
+        }
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch("custom_components.zaptec.statistics.get_last_statistics", return_value={}),
+        patch("custom_components.zaptec.statistics.async_add_external_statistics") as mock_add,
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        await coordinator._async_update_data()  # noqa: SLF001
+
+    assert mock_add.call_count == 1
+    _hass_arg, metadata, statistics = mock_add.call_args[0]
+    # StatisticMetaData and StatisticData are both TypedDicts (plain dicts at
+    # runtime) - use dict-key access, not attribute access.
+    assert metadata["statistic_id"] == "zaptec:energy_charger1"
+    assert metadata["name"] == "My Charger Energy"
+    assert len(statistics) == 1
+    assert statistics[0]["sum"] == 2.0  # noqa: PLR2004
+    charger.get_archived_sessions.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_new_sessions_does_not_call_add_statistics(
+    hass: MagicMock, config_entry: Any
+) -> None:
+    """If there's nothing new to import, async_add_external_statistics is not called."""
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        return_value={"Sessions": [], "Cursor": None, "HasMore": False}
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch("custom_components.zaptec.statistics.get_last_statistics", return_value={}),
+        patch("custom_components.zaptec.statistics.async_add_external_statistics") as mock_add,
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        await coordinator._async_update_data()  # noqa: SLF001
+
+    mock_add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resumes_from_last_statistics(hass: MagicMock, config_entry: Any) -> None:
+    """A prior statistics entry sets the resume point and running sum."""
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        return_value={"Sessions": [], "Cursor": None, "HasMore": False}
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+    last_start = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch(
+            "custom_components.zaptec.statistics.get_last_statistics",
+            return_value={
+                coordinator.statistic_id: [{"start": last_start.timestamp(), "sum": 42.0}]
+            },
+        ),
+        patch("custom_components.zaptec.statistics.async_add_external_statistics"),
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        await coordinator._async_update_data()  # noqa: SLF001
+
+    call_kwargs = charger.get_archived_sessions.call_args.kwargs
+    assert call_kwargs["from_time"] == last_start - timedelta(hours=26)
+    # to_time is "now" at call time - assert it's recent rather than exact.
+    assert (dt_util.utcnow() - call_kwargs["to_time"]) < timedelta(seconds=5)
+
+
+@pytest.mark.asyncio
+async def test_forbidden_error_is_logged_not_raised(hass: MagicMock, config_entry: Any) -> None:
+    """A 403 (non-Owner account) is logged and skipped, not raised as UpdateFailed.
+
+    /api/sessions/archived requires the Owner role - many Zaptec accounts
+    won't have it on every charger, and that shouldn't repeatedly fail the
+    coordinator/spam the log with UpdateFailed errors on every poll.
+    """
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        side_effect=RequestError("forbidden", HTTPStatus.FORBIDDEN)
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch("custom_components.zaptec.statistics.get_last_statistics", return_value={}),
+        patch("custom_components.zaptec.statistics.async_add_external_statistics") as mock_add,
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        await coordinator._async_update_data()  # noqa: SLF001
+
+    mock_add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_other_request_errors_raise_update_failed(
+    hass: MagicMock, config_entry: Any
+) -> None:
+    """A non-403 RequestError still raises UpdateFailed, so HA surfaces it normally."""
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        side_effect=RequestError("server error", HTTPStatus.INTERNAL_SERVER_ERROR)
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch("custom_components.zaptec.statistics.get_last_statistics", return_value={}),
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()  # noqa: SLF001

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -13,6 +13,7 @@ import pytest
 
 from custom_components.zaptec.statistics import (
     ZaptecStatisticsCoordinator,
+    _floor_hour,
     bucket_sessions_hourly,
 )
 from custom_components.zaptec.zaptec import Charger
@@ -55,12 +56,18 @@ def test_single_session_within_one_hour() -> None:
 
 
 def test_session_spanning_two_hours_creates_two_buckets() -> None:
-    """Points either side of an hour boundary land in different buckets."""
+    """Successive points landing in different hours produce separate buckets.
+
+    For back-to-back hourly reports (no gap), "the hour before this point"
+    and "the previous point's hour" are the same hour, so this is the
+    baseline case both attribution rules agree on.
+    """
     session = _session(
         "s1",
         [
-            ("2026-01-01T10:50:00+00:00", 1.0),
-            ("2026-01-01T11:20:00+00:00", 1.6),
+            ("2026-01-01T10:05:00+00:00", 0.0),
+            ("2026-01-01T11:00:00+00:00", 1.0),
+            ("2026-01-01T12:00:00+00:00", 1.6),
         ],
     )
 
@@ -76,16 +83,66 @@ def test_session_spanning_two_hours_creates_two_buckets() -> None:
     assert result[1]["sum"] == 2.6  # noqa: PLR2004
 
 
-def test_after_cutoff_excludes_already_imported_points() -> None:
-    """Points at or before `after` are skipped, avoiding double-counting."""
+def test_delta_after_a_multi_hour_gap_is_attributed_to_the_hour_before_the_report() -> None:
+    """A report following a multi-hour gap attributes to the hour before it.
+
+    Live-confirmed (2026-07-12, cross-checked against the charger's power
+    sensor): a report at 14:00 following a gap since 10:00 actually described
+    charging that happened around 13:00, not 10:00 (the gap's start hour).
+    """
     session = _session(
         "s1",
         [
-            ("2026-01-01T10:10:00+00:00", 1.0),
-            ("2026-01-01T11:10:00+00:00", 2.0),
+            ("2026-01-01T09:00:00+00:00", 0.0),
+            ("2026-01-01T10:00:00+00:00", 0.184),
+            ("2026-01-01T14:00:00+00:00", 0.212),  # 4-hour gap since the last report
         ],
     )
-    cutoff = datetime(2026, 1, 1, 10, 30, tzinfo=timezone.utc)  # noqa: UP017
+
+    result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
+
+    assert [r["start"] for r in result] == [
+        datetime(2026, 1, 1, 9, tzinfo=timezone.utc),  # noqa: UP017
+        datetime(2026, 1, 1, 13, tzinfo=timezone.utc),  # noqa: UP017
+    ]
+    assert result[0]["state"] == 0.184  # noqa: PLR2004
+    assert result[0]["sum"] == 0.184  # noqa: PLR2004
+    assert result[1]["state"] == 0.212  # noqa: PLR2004
+    assert result[1]["sum"] == 0.396  # noqa: PLR2004
+
+
+def test_session_end_is_not_walked_back_past_the_previous_report() -> None:
+    """A session's real end must use the previous report's hour, not its own.
+
+    Unlike a report on a scheduled hourly tick, an irregular end timestamp
+    isn't a tick to walk back an hour from.
+    """
+    session = _session(
+        "s1",
+        [
+            ("2026-01-01T14:00:00+00:00", 0.835),
+            ("2026-01-01T14:18:54+00:00", 0.279),
+        ],
+    )
+
+    result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
+
+    assert len(result) == 1
+    assert result[0]["start"] == datetime(2026, 1, 1, 14, tzinfo=timezone.utc)  # noqa: UP017
+    assert result[0]["state"] == 0.835 + 0.279
+
+
+def test_after_cutoff_excludes_already_imported_points() -> None:
+    """A delta whose interval starts at or before `after` is skipped, avoiding double-counting."""
+    session = _session(
+        "s1",
+        [
+            ("2026-01-01T10:10:00+00:00", 0.0),
+            ("2026-01-01T11:10:00+00:00", 1.0),
+            ("2026-01-01T12:10:00+00:00", 2.0),
+        ],
+    )
+    cutoff = datetime(2026, 1, 1, 10, tzinfo=timezone.utc)  # noqa: UP017
 
     result = bucket_sessions_hourly([session], after=cutoff, running_sum=5.0)
 
@@ -96,12 +153,17 @@ def test_after_cutoff_excludes_already_imported_points() -> None:
 
 
 def test_after_cutoff_excludes_entire_last_imported_hour() -> None:
-    """A point later in the same hour as `after` must not be re-counted (regression: was double-counting)."""
+    """A delta whose raw timestamp is past `after` must still be excluded.
+
+    This applies if its interval started within the already-imported hour
+    (regression: was double-counting).
+    """
     session = _session(
         "s1",
         [
-            ("2026-01-01T11:10:00+00:00", 1.0),
-            ("2026-01-01T12:05:00+00:00", 1.5),
+            ("2026-01-01T11:50:00+00:00", 0.0),
+            ("2026-01-01T12:50:00+00:00", 1.5),
+            ("2026-01-01T13:50:00+00:00", 2.0),
         ],
     )
     after = datetime(2026, 1, 1, 11, tzinfo=timezone.utc)  # noqa: UP017
@@ -110,8 +172,8 @@ def test_after_cutoff_excludes_entire_last_imported_hour() -> None:
 
     assert len(result) == 1
     assert result[0]["start"] == datetime(2026, 1, 1, 12, tzinfo=timezone.utc)  # noqa: UP017
-    assert result[0]["state"] == 1.5  # noqa: PLR2004
-    assert result[0]["sum"] == 4.5  # noqa: PLR2004
+    assert result[0]["state"] == 2.0  # noqa: PLR2004
+    assert result[0]["sum"] == 5.0  # noqa: PLR2004
 
 
 def test_session_without_energy_details_falls_back_to_total() -> None:
@@ -172,6 +234,23 @@ def test_bucket_sessions_hourly_uses_camelcase_keys() -> None:
 
     assert len(result) == 1
     assert result[0]["state"] == 1.5  # noqa: PLR2004
+
+
+def test_floor_hour_snaps_reports_a_few_seconds_early_to_the_next_hour() -> None:
+    """A report a few seconds early still floors to its intended hour.
+
+    Zaptec reports land within ~200ms of the hour in practice, but nothing
+    guarantees that across all firmware/devices.
+    """
+    noon = datetime(2026, 1, 1, 12, tzinfo=timezone.utc)  # noqa: UP017
+    eleven = datetime(2026, 1, 1, 11, tzinfo=timezone.utc)  # noqa: UP017
+
+    # Comfortably inside the hour: floors normally, no snapping.
+    assert _floor_hour(datetime(2026, 1, 1, 12, 0, 3, tzinfo=timezone.utc)) == noon  # noqa: UP017
+    # A few seconds early: within tolerance, snaps up to the intended hour.
+    assert _floor_hour(datetime(2026, 1, 1, 11, 59, 58, tzinfo=timezone.utc)) == noon  # noqa: UP017
+    # Comfortably early (outside tolerance): floors down as normal.
+    assert _floor_hour(datetime(2026, 1, 1, 11, 59, 50, tzinfo=timezone.utc)) == eleven  # noqa: UP017
 
 
 def _make_charger(charger_id: str = "charger-1") -> MagicMock:

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,119 @@
+"""Tests for statistics.py."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from custom_components.zaptec.statistics import bucket_sessions_hourly
+
+
+def _session(
+    session_id: str,
+    points: list[tuple[str, float]],
+    *,
+    end: str | None = None,
+    energy: float = 0.0,
+) -> dict:
+    """Build a raw archived-session dict with the given EnergyDetails points."""
+    return {
+        "Id": session_id,
+        "EndDateTime": end,
+        "Energy": energy,
+        "EnergyDetails": [{"Timestamp": ts, "Energy": e} for ts, e in points],
+    }
+
+
+def test_single_session_within_one_hour() -> None:
+    """A session with all points inside one hour produces a single bucket."""
+    session = _session(
+        "s1", [("2026-01-01T10:10:00+00:00", 1.0), ("2026-01-01T10:40:00+00:00", 2.5)]
+    )
+
+    result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
+
+    assert len(result) == 1
+    assert result[0].start == datetime(2026, 1, 1, 10, tzinfo=timezone.utc)  # noqa: UP017
+    assert result[0].state == 2.5  # noqa: PLR2004
+    assert result[0].sum == 2.5  # noqa: PLR2004
+
+
+def test_session_spanning_two_hours_creates_two_buckets() -> None:
+    """Points either side of an hour boundary land in different buckets."""
+    session = _session(
+        "s1",
+        [
+            ("2026-01-01T10:50:00+00:00", 1.0),
+            ("2026-01-01T11:20:00+00:00", 1.6),
+        ],
+    )
+
+    result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
+
+    assert [r.start for r in result] == [
+        datetime(2026, 1, 1, 10, tzinfo=timezone.utc),  # noqa: UP017
+        datetime(2026, 1, 1, 11, tzinfo=timezone.utc),  # noqa: UP017
+    ]
+    assert result[0].state == 1.0
+    assert result[0].sum == 1.0
+    assert result[1].state == 0.6000000000000001  # noqa: PLR2004
+    assert result[1].sum == 1.6  # noqa: PLR2004
+
+
+def test_after_cutoff_excludes_already_imported_points() -> None:
+    """Points at or before `after` are skipped, avoiding double-counting."""
+    session = _session(
+        "s1",
+        [
+            ("2026-01-01T10:10:00+00:00", 1.0),
+            ("2026-01-01T11:10:00+00:00", 2.0),
+        ],
+    )
+    cutoff = datetime(2026, 1, 1, 10, 30, tzinfo=timezone.utc)  # noqa: UP017
+
+    result = bucket_sessions_hourly([session], after=cutoff, running_sum=5.0)
+
+    assert len(result) == 1
+    assert result[0].start == datetime(2026, 1, 1, 11, tzinfo=timezone.utc)  # noqa: UP017
+    assert result[0].state == 1.0
+    assert result[0].sum == 6.0  # noqa: PLR2004
+
+
+def test_session_without_energy_details_falls_back_to_total() -> None:
+    """A legacy session with no EnergyDetails uses its total Energy at EndDateTime."""
+    session = {
+        "Id": "s1",
+        "EndDateTime": "2026-01-01T10:45:00+00:00",
+        "Energy": 3.0,
+        "EnergyDetails": [],
+    }
+
+    result = bucket_sessions_hourly([session], after=None, running_sum=0.0)
+
+    assert len(result) == 1
+    assert result[0].start == datetime(2026, 1, 1, 10, tzinfo=timezone.utc)  # noqa: UP017
+    assert result[0].state == 3.0  # noqa: PLR2004
+
+
+def test_running_sum_carries_across_sessions() -> None:
+    """The running sum accumulates across multiple sessions, oldest first."""
+    session1 = _session("s1", [("2026-01-01T10:10:00+00:00", 1.0)])
+    session2 = _session("s2", [("2026-01-01T12:10:00+00:00", 2.0)])
+
+    result = bucket_sessions_hourly([session1, session2], after=None, running_sum=10.0)
+
+    assert [r.sum for r in result] == [11.0, 13.0]
+
+
+def test_voided_and_aborted_sessions_are_skipped() -> None:
+    """Voided/aborted sessions have no meaningful energy and must not be counted."""
+    voided = _session("s1", [("2026-01-01T10:10:00+00:00", 1.0)])
+    voided["Voided"] = True
+    aborted = _session("s2", [("2026-01-01T11:10:00+00:00", 2.0)])
+    aborted["Aborted"] = True
+    real = _session("s3", [("2026-01-01T12:10:00+00:00", 3.0)])
+
+    result = bucket_sessions_hourly([voided, aborted, real], after=None, running_sum=0.0)
+
+    assert len(result) == 1
+    assert result[0].start == datetime(2026, 1, 1, 12, tzinfo=timezone.utc)  # noqa: UP017
+    assert result[0].state == 3.0  # noqa: PLR2004

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -90,6 +90,25 @@ def test_after_cutoff_excludes_already_imported_points() -> None:
     assert result[0]["sum"] == 6.0  # noqa: PLR2004
 
 
+def test_after_cutoff_excludes_entire_last_imported_hour() -> None:
+    """A point later in the same hour as `after` must not be re-counted (regression: was double-counting)."""
+    session = _session(
+        "s1",
+        [
+            ("2026-01-01T11:10:00+00:00", 1.0),
+            ("2026-01-01T12:05:00+00:00", 1.5),
+        ],
+    )
+    after = datetime(2026, 1, 1, 11, tzinfo=timezone.utc)  # noqa: UP017
+
+    result = bucket_sessions_hourly([session], after=after, running_sum=3.0)
+
+    assert len(result) == 1
+    assert result[0]["start"] == datetime(2026, 1, 1, 12, tzinfo=timezone.utc)  # noqa: UP017
+    assert result[0]["state"] == 0.5  # noqa: PLR2004
+    assert result[0]["sum"] == 3.5  # noqa: PLR2004
+
+
 def test_session_without_energy_details_falls_back_to_total() -> None:
     """A legacy session with no EnergyDetails uses its total Energy at EndDateTime."""
     session = {

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -381,3 +381,73 @@ async def test_pages_through_multiple_results(hass: MagicMock, config_entry: Any
     _hass_arg, _metadata, statistics = mock_add.call_args[0]
     assert len(statistics) == 2  # noqa: PLR2004
     assert [s["sum"] for s in statistics] == [1.0, 3.0]
+
+
+@pytest.mark.asyncio
+async def test_metadata_includes_unit_class_when_supported(
+    hass: MagicMock, config_entry: Any
+) -> None:
+    """unit_class is included in the metadata when the installed HA core supports it."""
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        return_value={
+            "sessions": [
+                {
+                    "id": "s1",
+                    "energyDetails": [{"timestamp": "2026-01-01T10:10:00+00:00", "energy": 2.0}],
+                }
+            ],
+            "cursor": None,
+            "hasMore": False,
+        }
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch("custom_components.zaptec.statistics.get_last_statistics", return_value={}),
+        patch("custom_components.zaptec.statistics.async_add_external_statistics") as mock_add,
+        patch("custom_components.zaptec.statistics._SUPPORTS_UNIT_CLASS", new=True),
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        await coordinator._async_update_data()  # noqa: SLF001
+
+    _hass_arg, metadata, _statistics = mock_add.call_args[0]
+    assert "unit_class" in metadata
+
+
+@pytest.mark.asyncio
+async def test_metadata_omits_unit_class_when_unsupported(
+    hass: MagicMock, config_entry: Any
+) -> None:
+    """unit_class is omitted entirely on older HA cores whose StatisticsMeta lacks the column."""
+    charger = _make_charger()
+    charger.get_archived_sessions = AsyncMock(
+        return_value={
+            "sessions": [
+                {
+                    "id": "s1",
+                    "energyDetails": [{"timestamp": "2026-01-01T10:10:00+00:00", "energy": 2.0}],
+                }
+            ],
+            "cursor": None,
+            "hasMore": False,
+        }
+    )
+    coordinator = ZaptecStatisticsCoordinator(hass, entry=config_entry, charger=charger)
+
+    with (
+        patch("custom_components.zaptec.statistics.get_instance") as mock_get_instance,
+        patch("custom_components.zaptec.statistics.get_last_statistics", return_value={}),
+        patch("custom_components.zaptec.statistics.async_add_external_statistics") as mock_add,
+        patch("custom_components.zaptec.statistics._SUPPORTS_UNIT_CLASS", new=False),
+    ):
+        mock_get_instance.return_value.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        await coordinator._async_update_data()  # noqa: SLF001
+
+    _hass_arg, metadata, _statistics = mock_add.call_args[0]
+    assert "unit_class" not in metadata

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,232 @@
+"""Tests for switch.py."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+import pytest
+
+from custom_components.zaptec.coordinator import ZaptecUpdateCoordinator, ZaptecUpdateOptions
+from custom_components.zaptec.switch import (
+    ZapSwitchEntityDescription,
+    ZaptecCableLockSwitch,
+    ZaptecChargeSwitch,
+    ZaptecSwitch,
+)
+from custom_components.zaptec.zaptec import Charger
+
+
+@pytest.fixture
+def coordinator(hass: MagicMock, config_entry: Any) -> ZaptecUpdateCoordinator:
+    """Create a ZaptecUpdateCoordinator for testing."""
+    manager = MagicMock()
+    options = ZaptecUpdateOptions(
+        name="test",
+        update_interval=600,
+        charging_update_interval=None,
+        tracked_devices=set(),
+        poll_args={},
+        zaptec_object=None,
+    )
+    return ZaptecUpdateCoordinator(hass, entry=config_entry, manager=manager, options=options)
+
+
+def make_charger(data: dict[str, Any]) -> MagicMock:
+    """Create a MagicMock(spec=Charger) whose .get() reads from data."""
+    charger = MagicMock(spec=Charger)
+    charger.id = "charger1"
+    charger.qual_id = "Charger[charger1]"
+    charger.get.side_effect = data.get
+    return charger
+
+
+def test_switch_update_from_zaptec_sets_is_on(coordinator: ZaptecUpdateCoordinator) -> None:
+    """ZaptecSwitch._update_from_zaptec reads the raw boolean value for its key."""
+    charger = make_charger({"permanent_cable_lock": True})
+    description = ZapSwitchEntityDescription(key="permanent_cable_lock", cls=ZaptecSwitch)
+    entity = ZaptecSwitch(coordinator, charger, description, DeviceInfo())
+
+    entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_is_on is True  # noqa: SLF001
+    assert entity._attr_available is True  # noqa: SLF001
+
+
+def test_charge_switch_update_from_zaptec_true_only_when_charging(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecChargeSwitch is only "on" when the mode is exactly Connected_Charging."""
+    charger = make_charger({"charger_operation_mode": "Connected_Charging"})
+    description = ZapSwitchEntityDescription(key="charger_operation_mode", cls=ZaptecChargeSwitch)
+    entity = ZaptecChargeSwitch(coordinator, charger, description, DeviceInfo())
+
+    entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_is_on is True  # noqa: SLF001
+
+
+def test_charge_switch_available_checks_stop_command_when_on(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """When on, ZaptecChargeSwitch.available checks the stop_charging_final command."""
+    charger = make_charger({})
+    charger.is_command_valid.return_value = True
+    description = ZapSwitchEntityDescription(key="charger_operation_mode", cls=ZaptecChargeSwitch)
+    entity = ZaptecChargeSwitch(coordinator, charger, description, DeviceInfo())
+    entity._attr_is_on = True  # noqa: SLF001
+
+    assert entity.available is True
+    charger.is_command_valid.assert_called_once_with("stop_charging_final")
+
+
+def test_charge_switch_available_checks_resume_command_when_off(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """When off, ZaptecChargeSwitch.available checks the resume_charging command."""
+    charger = make_charger({})
+    charger.is_command_valid.return_value = False
+    description = ZapSwitchEntityDescription(key="charger_operation_mode", cls=ZaptecChargeSwitch)
+    entity = ZaptecChargeSwitch(coordinator, charger, description, DeviceInfo())
+    entity._attr_is_on = False  # noqa: SLF001
+
+    assert entity.available is False
+    charger.is_command_valid.assert_called_once_with("resume_charging")
+
+
+async def test_charge_switch_turn_on_resumes_charging_and_polls(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_turn_on sends resume_charging and triggers a poll on success."""
+    charger = make_charger({})
+    charger.command = AsyncMock()
+    description = ZapSwitchEntityDescription(key="charger_operation_mode", cls=ZaptecChargeSwitch)
+    entity = ZaptecChargeSwitch(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    await entity.async_turn_on()
+
+    charger.command.assert_awaited_once_with("resume_charging")
+    entity.trigger_poll.assert_awaited_once()
+
+
+async def test_charge_switch_turn_on_wraps_command_failure(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_turn_on wraps a command failure in HomeAssistantError and skips the poll."""
+    charger = make_charger({})
+    charger.command = AsyncMock(side_effect=Exception("boom"))
+    description = ZapSwitchEntityDescription(key="charger_operation_mode", cls=ZaptecChargeSwitch)
+    entity = ZaptecChargeSwitch(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_turn_on()
+
+    entity.trigger_poll.assert_not_called()
+
+
+async def test_charge_switch_turn_off_stops_charging_and_polls(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_turn_off sends stop_charging_final and triggers a poll on success."""
+    charger = make_charger({})
+    charger.command = AsyncMock()
+    description = ZapSwitchEntityDescription(key="charger_operation_mode", cls=ZaptecChargeSwitch)
+    entity = ZaptecChargeSwitch(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    await entity.async_turn_off()
+
+    charger.command.assert_awaited_once_with("stop_charging_final")
+    entity.trigger_poll.assert_awaited_once()
+
+
+async def test_charge_switch_turn_off_wraps_command_failure(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_turn_off wraps a command failure in HomeAssistantError and skips the poll."""
+    charger = make_charger({})
+    charger.command = AsyncMock(side_effect=Exception("boom"))
+    description = ZapSwitchEntityDescription(key="charger_operation_mode", cls=ZaptecChargeSwitch)
+    entity = ZaptecChargeSwitch(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_turn_off()
+
+    entity.trigger_poll.assert_not_called()
+
+
+async def test_cable_lock_switch_turn_on_locks_and_polls(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_turn_on locks the cable and triggers a poll on success."""
+    charger = make_charger({})
+    charger.set_permanent_cable_lock = AsyncMock()
+    description = ZapSwitchEntityDescription(
+        key="permanent_cable_lock", cls=ZaptecCableLockSwitch
+    )
+    entity = ZaptecCableLockSwitch(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    await entity.async_turn_on()
+
+    charger.set_permanent_cable_lock.assert_awaited_once_with(True)  # noqa: FBT003
+    entity.trigger_poll.assert_awaited_once()
+
+
+async def test_cable_lock_switch_turn_on_wraps_failure(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_turn_on wraps a failure in HomeAssistantError and skips the poll."""
+    charger = make_charger({})
+    charger.set_permanent_cable_lock = AsyncMock(side_effect=Exception("boom"))
+    description = ZapSwitchEntityDescription(
+        key="permanent_cable_lock", cls=ZaptecCableLockSwitch
+    )
+    entity = ZaptecCableLockSwitch(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_turn_on()
+
+    entity.trigger_poll.assert_not_called()
+
+
+async def test_cable_lock_switch_turn_off_unlocks_and_polls(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_turn_off unlocks the cable and triggers a poll on success."""
+    charger = make_charger({})
+    charger.set_permanent_cable_lock = AsyncMock()
+    description = ZapSwitchEntityDescription(
+        key="permanent_cable_lock", cls=ZaptecCableLockSwitch
+    )
+    entity = ZaptecCableLockSwitch(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    await entity.async_turn_off()
+
+    charger.set_permanent_cable_lock.assert_awaited_once_with(False)  # noqa: FBT003
+    entity.trigger_poll.assert_awaited_once()
+
+
+async def test_cable_lock_switch_turn_off_wraps_failure(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_turn_off wraps a failure in HomeAssistantError and skips the poll."""
+    charger = make_charger({})
+    charger.set_permanent_cable_lock = AsyncMock(side_effect=Exception("boom"))
+    description = ZapSwitchEntityDescription(
+        key="permanent_cable_lock", cls=ZaptecCableLockSwitch
+    )
+    entity = ZaptecCableLockSwitch(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_turn_off()
+
+    entity.trigger_poll.assert_not_called()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,88 @@
+"""Tests for update.py."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+import pytest
+
+from custom_components.zaptec.coordinator import ZaptecUpdateCoordinator, ZaptecUpdateOptions
+from custom_components.zaptec.update import ZaptecUpdate, ZapUpdateEntityDescription
+from custom_components.zaptec.zaptec import Charger
+
+
+@pytest.fixture
+def coordinator(hass: MagicMock, config_entry: Any) -> ZaptecUpdateCoordinator:
+    """Create a ZaptecUpdateCoordinator for testing."""
+    manager = MagicMock()
+    options = ZaptecUpdateOptions(
+        name="test",
+        update_interval=600,
+        charging_update_interval=None,
+        tracked_devices=set(),
+        poll_args={},
+        zaptec_object=None,
+    )
+    return ZaptecUpdateCoordinator(hass, entry=config_entry, manager=manager, options=options)
+
+
+def make_charger(data: dict[str, Any]) -> MagicMock:
+    """Create a MagicMock(spec=Charger) whose .get() reads from data."""
+    charger = MagicMock(spec=Charger)
+    charger.id = "charger1"
+    charger.qual_id = "Charger[charger1]"
+    charger.get.side_effect = data.get
+    return charger
+
+
+def test_update_from_zaptec_sets_installed_and_latest_version(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """ZaptecUpdate._update_from_zaptec reads both firmware version keys."""
+    charger = make_charger(
+        {
+            "firmware_current_version": "1.0.0",
+            "firmware_available_version": "1.1.0",
+        }
+    )
+    description = ZapUpdateEntityDescription(key="firmware_update", cls=ZaptecUpdate)
+    entity = ZaptecUpdate(coordinator, charger, description, DeviceInfo())
+
+    entity._update_from_zaptec()  # noqa: SLF001
+
+    assert entity._attr_installed_version == "1.0.0"  # noqa: SLF001
+    assert entity._attr_latest_version == "1.1.0"  # noqa: SLF001
+    assert entity._attr_available is True  # noqa: SLF001
+
+
+async def test_async_install_sends_upgrade_firmware_and_polls(
+    coordinator: ZaptecUpdateCoordinator,
+) -> None:
+    """async_install sends the upgrade_firmware command and triggers a poll on success."""
+    charger = make_charger({})
+    charger.command = AsyncMock()
+    description = ZapUpdateEntityDescription(key="firmware_update", cls=ZaptecUpdate)
+    entity = ZaptecUpdate(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    await entity.async_install(version=None, backup=False)
+
+    charger.command.assert_awaited_once_with("upgrade_firmware")
+    entity.trigger_poll.assert_awaited_once()
+
+
+async def test_async_install_wraps_command_failure(coordinator: ZaptecUpdateCoordinator) -> None:
+    """async_install wraps a command failure in HomeAssistantError and skips the poll."""
+    charger = make_charger({})
+    charger.command = AsyncMock(side_effect=Exception("boom"))
+    description = ZapUpdateEntityDescription(key="firmware_update", cls=ZaptecUpdate)
+    entity = ZaptecUpdate(coordinator, charger, description, DeviceInfo())
+    entity.trigger_poll = AsyncMock()
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_install(version=None, backup=False)
+
+    entity.trigger_poll.assert_not_called()

--- a/tests/zaptec/test_api.py
+++ b/tests/zaptec/test_api.py
@@ -1,10 +1,25 @@
 """Tests for zaptec/api.py."""
 
+from http import HTTPStatus
+import json
 import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
+import aiohttp
 import pytest
 
-from custom_components.zaptec.zaptec.api import Zaptec
+from custom_components.zaptec.zaptec.api import Charger, Installation, Zaptec, ZaptecBase
+from custom_components.zaptec.zaptec.const import API_RETRIES
+from custom_components.zaptec.zaptec.exceptions import (
+    RequestConnectionError,
+    RequestDataError,
+    RequestError,
+    RequestRetryError,
+    RequestTimeoutError,
+)
+from custom_components.zaptec.zaptec.redact import Redactor
+from custom_components.zaptec.zaptec.zconst import ZCONST
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,3 +48,458 @@ async def test_api(zaptec_username: str, zaptec_password: str) -> None:
         # Print all the attributes.
         for obj in zaptec.objects():
             _LOGGER.info(obj.asdict())
+
+
+# ===========================================================================
+#   Offline unit tests (no network / no live login required)
+# ===========================================================================
+#
+# These exercise the pure logic and the request/retry machinery using a fake
+# aiohttp ClientSession, so they run without credentials or DNS access.
+
+
+class FakeResponse:
+    """Minimal stand-in for aiohttp.ClientResponse."""
+
+    def __init__(
+        self,
+        status: int,
+        *,
+        json_data: object = None,
+        read_data: bytes = b"",
+        text_data: str = "",
+        headers: dict | None = None,
+    ) -> None:
+        """Store the canned response data."""
+        self.status = status
+        self._json_data = json_data
+        self._read_data = read_data
+        self._text_data = text_data
+        self.headers = headers or {}
+
+    async def json(self, content_type: str | None = None) -> object:
+        """Return the canned JSON body, or raise if none was configured."""
+        if self._json_data is None:
+            raise json.JSONDecodeError("no json body", "", 0)
+        return self._json_data
+
+    async def read(self) -> bytes:
+        """Return the canned raw body."""
+        return self._read_data
+
+    async def text(self) -> str:
+        """Return the canned text body."""
+        return self._text_data
+
+
+class _FakeRequestCM:
+    """Async context manager returned by FakeSession.request()."""
+
+    def __init__(
+        self, *, response: FakeResponse | None = None, exc: BaseException | None = None
+    ) -> None:
+        """Store the response to yield, or the exception to raise on enter."""
+        self._response = response
+        self._exc = exc
+
+    async def __aenter__(self) -> FakeResponse:
+        """Raise the configured exception, or return the response."""
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        """Never suppress exceptions."""
+        return False
+
+
+class FakeSession:
+    """Minimal aiohttp.ClientSession stand-in driven by a list of outcomes.
+
+    Each call to request() consumes the next outcome (a FakeResponse to yield
+    or an exception to raise); the last outcome repeats for further calls.
+    """
+
+    def __init__(self, outcomes: list[FakeResponse | BaseException]) -> None:
+        """Store the sequence of per-call outcomes."""
+        self._outcomes = outcomes
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def request(self, *, method: str, url: str, **kwargs: object) -> _FakeRequestCM:
+        """Record the call and return the matching outcome."""
+        idx = len(self.calls)
+        self.calls.append((method, url, kwargs))
+        outcome = self._outcomes[min(idx, len(self._outcomes) - 1)]
+        if isinstance(outcome, BaseException):
+            return _FakeRequestCM(exc=outcome)
+        return _FakeRequestCM(response=outcome)
+
+    async def close(self) -> None:
+        """No-op close."""
+
+
+def _make_zaptec(
+    outcomes: list[FakeResponse | BaseException], **kwargs: object
+) -> tuple[Zaptec, FakeSession]:
+    """Build a Zaptec client backed by a FakeSession, returning both."""
+    session = FakeSession(outcomes)
+    zap = Zaptec("user", "pass", client=session, redact_logs=False, **kwargs)
+    return zap, session
+
+
+def _fake_owner() -> SimpleNamespace:
+    """Return a stand-in for the `zaptec` owner used by set_attributes."""
+    return SimpleNamespace(redact=Redactor(do_redact=False), show_all_updates=False)
+
+
+# ---------------------------------------------------------------------------
+#   Zaptec.request status handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_ok_returns_json() -> None:
+    """A 200 response returns the decoded JSON payload."""
+    payload = {"value": "answer"}
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.OK, json_data=payload)])
+    result = await zap.request("unregistered/url")
+    assert result == payload
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_request_no_content_returns_bytes() -> None:
+    """A 204/201 response returns the raw body bytes."""
+    zap, _ = _make_zaptec([FakeResponse(HTTPStatus.NO_CONTENT, read_data=b"done")])
+    result = await zap.request("unregistered/url", method="post")
+    assert result == b"done"
+
+
+@pytest.mark.asyncio
+async def test_request_invalid_json_raises_data_error() -> None:
+    """A 200 with an undecodable body raises RequestDataError."""
+    zap, _ = _make_zaptec([FakeResponse(HTTPStatus.OK, json_data=None)])
+    with pytest.raises(RequestDataError):
+        await zap.request("unregistered/url")
+
+
+@pytest.mark.asyncio
+async def test_request_error_status_raises_with_code() -> None:
+    """A non-retryable error status raises RequestError carrying the code."""
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.NOT_FOUND)])
+    with pytest.raises(RequestError) as excinfo:
+        await zap.request("unregistered/url")
+    assert excinfo.value.error_code == HTTPStatus.NOT_FOUND
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_request_500_on_post_raises_immediately() -> None:
+    """A 500 on a POST is not retried and raises RequestError immediately."""
+    zap, session = _make_zaptec(
+        [FakeResponse(HTTPStatus.INTERNAL_SERVER_ERROR, text_data="server error")]
+    )
+    with pytest.raises(RequestError) as excinfo:
+        await zap.request("unregistered/url", method="post")
+    assert excinfo.value.error_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_request_500_on_get_retries_then_raises_retry_error() -> None:
+    """A persistent 500 on a GET is retried until exhaustion (RequestRetryError)."""
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.INTERNAL_SERVER_ERROR)], max_time=0.001)
+    with pytest.raises(RequestRetryError):
+        await zap.request("unregistered/url")
+    assert len(session.calls) == API_RETRIES
+
+
+@pytest.mark.asyncio
+async def test_request_401_refreshes_token_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 401 triggers a token refresh and the request is retried."""
+    payload = {"ok": "yes"}
+    zap, _ = _make_zaptec(
+        [FakeResponse(HTTPStatus.UNAUTHORIZED), FakeResponse(HTTPStatus.OK, json_data=payload)]
+    )
+    refresh = AsyncMock()
+    monkeypatch.setattr(zap, "_refresh_token", refresh)
+
+    result = await zap.request("unregistered/url")
+    # Reaching the 200 payload after a 401 proves the request was retried.
+    assert result == payload
+    refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_request_connection_error_retried_then_raises() -> None:
+    """Connection errors are retried and finally raise RequestConnectionError."""
+    zap, session = _make_zaptec([aiohttp.ClientConnectionError("boom")], max_time=0.001)
+    with pytest.raises(RequestConnectionError):
+        await zap.request("unregistered/url")
+    assert len(session.calls) == API_RETRIES
+
+
+@pytest.mark.asyncio
+async def test_request_timeout_retried_then_raises() -> None:
+    """Timeouts are retried and finally raise RequestTimeoutError."""
+    zap, session = _make_zaptec([TimeoutError()], max_time=0.001)
+    with pytest.raises(RequestTimeoutError):
+        await zap.request("unregistered/url")
+    assert len(session.calls) == API_RETRIES
+
+
+# ---------------------------------------------------------------------------
+#   ZaptecBase.state_to_attrs
+# ---------------------------------------------------------------------------
+
+
+def test_state_to_attrs_maps_and_prefers_value() -> None:
+    """Values are mapped via keydict; `Value` wins over `ValueAsString`."""
+    keydict = {"1": "current", "2": "voltage"}
+    data = [
+        {"StateId": "1", "ValueAsString": "10"},
+        {"StateId": "2", "Value": "230", "ValueAsString": "ignored"},
+    ]
+    out = ZaptecBase.state_to_attrs(data, "StateId", keydict)
+    assert out == {"current": "10", "voltage": "230"}
+
+
+def test_state_to_attrs_unknown_key_uses_fallback_name() -> None:
+    """A StateId missing from keydict falls back to '<key> <id>'."""
+    out = ZaptecBase.state_to_attrs([{"StateId": "99", "Value": "x"}], "StateId", {})
+    assert out == {"StateId 99": "x"}
+
+
+def test_state_to_attrs_skips_missing_key_and_missing_value() -> None:
+    """Entries without the key, or without any value, are skipped."""
+    data = [
+        {"NoStateId": "1", "Value": "x"},  # missing key -> skipped
+        {"StateId": "1"},  # no Value/ValueAsString -> skipped
+    ]
+    out = ZaptecBase.state_to_attrs(data, "StateId", {"1": "current"})
+    assert out == {}
+
+
+def test_state_to_attrs_excludes() -> None:
+    """Excluded ids are dropped."""
+    data = [
+        {"StateId": "1", "Value": "a"},
+        {"StateId": "2", "Value": "b"},
+    ]
+    out = ZaptecBase.state_to_attrs(data, "StateId", {"1": "one", "2": "two"}, excludes={"2"})
+    assert out == {"one": "a"}
+
+
+def test_state_to_attrs_duplicate_last_wins() -> None:
+    """When two entries map to the same attribute, the last one wins."""
+    data = [
+        {"StateId": "1", "Value": "first"},
+        {"StateId": "1", "Value": "second"},
+    ]
+    out = ZaptecBase.state_to_attrs(data, "StateId", {"1": "current"})
+    assert out == {"current": "second"}
+
+
+# ---------------------------------------------------------------------------
+#   ZaptecBase.set_attributes type conversion
+# ---------------------------------------------------------------------------
+
+
+def test_set_attributes_applies_type_conversion() -> None:
+    """Known attributes are converted per ATTR_TYPES; keys become snake_case."""
+    chg = Charger(
+        {"ChargerMaxCurrent": "16", "IsOnline": "true", "Name": "Garage"}, _fake_owner()
+    )
+    assert chg["ChargerMaxCurrent"] == float("16")
+    assert chg["IsOnline"] is True
+    assert chg["Name"] == "Garage"
+
+
+def test_set_attributes_unknown_key_passthrough() -> None:
+    """Unknown attributes are stored unchanged under a snake_case key."""
+    chg = Charger({"SomeUnknownKey": "value"}, _fake_owner())
+    assert chg["SomeUnknownKey"] == "value"
+    assert "some_unknown_key" in chg.asdict()
+
+
+def test_set_attributes_conversion_failure_falls_back_to_raw() -> None:
+    """A failing type conversion keeps the raw value instead of raising."""
+    chg = Charger({"ChargerMaxCurrent": "not-a-number"}, _fake_owner())
+    assert chg["ChargerMaxCurrent"] == "not-a-number"
+
+
+def test_set_attributes_updates_existing_value() -> None:
+    """Re-setting an attribute overwrites the previous value."""
+    chg = Charger({"ChargerMaxCurrent": "16"}, _fake_owner())
+    chg.set_attributes({"ChargerMaxCurrent": "32"})
+    assert chg["ChargerMaxCurrent"] == float("32")
+
+
+# ---------------------------------------------------------------------------
+#   Charger.is_command_valid
+# ---------------------------------------------------------------------------
+
+
+def _charger_with_state(
+    *, operation_mode: str | None = None, final_stop_active: str | None = None
+) -> Charger:
+    """Build a Charger carrying the state attributes is_command_valid reads."""
+    data: dict[str, str] = {"Id": "chg-1"}
+    if operation_mode is not None:
+        data["ChargerOperationMode"] = operation_mode
+    if final_stop_active is not None:
+        data["FinalStopActive"] = final_stop_active
+    return Charger(data, _fake_owner())
+
+
+def test_is_command_valid_unrelated_command_is_always_valid() -> None:
+    """Commands other than resume/stop are always valid (no state needed)."""
+    chg = _charger_with_state()
+    assert chg.is_command_valid("restart_charger", raise_value_error_if_invalid=True) is True
+
+
+def test_is_command_valid_resume_when_paused_is_valid() -> None:
+    """Resume is allowed only when the charger is paused."""
+    chg = _charger_with_state(operation_mode="Connected_Finished", final_stop_active="1")
+    assert chg.is_command_valid("resume_charging") is True
+
+
+def test_is_command_valid_resume_when_not_paused_is_invalid() -> None:
+    """Resume is rejected when not paused, and raises when requested."""
+    chg = _charger_with_state(operation_mode="Connected_Charging", final_stop_active="0")
+    assert chg.is_command_valid("resume_charging") is False
+    with pytest.raises(ValueError, match="not paused"):
+        chg.is_command_valid("resume_charging", raise_value_error_if_invalid=True)
+
+
+def test_is_command_valid_stop_when_paused_is_invalid() -> None:
+    """Stop/pause is rejected when already paused."""
+    chg = _charger_with_state(operation_mode="Connected_Finished", final_stop_active="1")
+    assert chg.is_command_valid("stop_charging_final") is False
+
+
+def test_is_command_valid_stop_when_disconnected_is_invalid() -> None:
+    """Stop/pause is rejected when disconnected."""
+    chg = _charger_with_state(operation_mode="Disconnected", final_stop_active="0")
+    assert chg.is_command_valid("stop_charging_final") is False
+
+
+def test_is_command_valid_stop_when_charging_is_valid() -> None:
+    """Stop/pause is allowed while actively charging."""
+    chg = _charger_with_state(operation_mode="Connected_Charging", final_stop_active="0")
+    assert chg.is_command_valid("stop_charging_final") is True
+
+
+def test_is_command_valid_missing_final_stop_raises_type_error() -> None:
+    """KNOWN ISSUE (Phase 3): a missing FinalStopActive makes int(None) raise.
+
+    Characterizes current behavior; the correctness cleanup should guard this.
+    """
+    chg = _charger_with_state(operation_mode="Connected_Finished")
+    with pytest.raises(TypeError):
+        chg.is_command_valid("resume_charging")
+
+
+# ---------------------------------------------------------------------------
+#   Installation.stream_update routing
+# ---------------------------------------------------------------------------
+
+
+def _installation_with_charger() -> tuple[Installation, Charger]:
+    """Build an installation owning a single charger spy."""
+    owner = _fake_owner()
+    inst = Installation({"Id": "inst-1"}, owner)
+    charger = Charger({"Id": "chg-1"}, owner)
+    charger.set_attributes = Mock()  # spy on the routed update
+    inst.chargers = [charger]
+    return inst, charger
+
+
+def test_stream_update_routes_to_matching_charger(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A message with a known ChargerId updates that charger."""
+    # observations is populated by build(); inject it for this offline test.
+    monkeypatch.setattr(ZCONST, "observations", {"1": "current"}, raising=False)
+    inst, charger = _installation_with_charger()
+    inst.stream_update({"ChargerId": "chg-1", "StateId": "1", "ValueAsString": "5"})
+    charger.set_attributes.assert_called_once()
+
+
+def test_stream_update_unknown_charger_is_ignored() -> None:
+    """A message for an unknown charger does not update anything."""
+    inst, charger = _installation_with_charger()
+    inst.stream_update({"ChargerId": "other", "StateId": "1", "ValueAsString": "5"})
+    charger.set_attributes.assert_not_called()
+
+
+def test_stream_update_missing_charger_id_is_ignored() -> None:
+    """A message without a ChargerId is ignored."""
+    inst, charger = _installation_with_charger()
+    inst.stream_update({"StateId": "1", "ValueAsString": "5"})
+    charger.set_attributes.assert_not_called()
+
+
+def test_stream_update_zero_guid_is_ignored() -> None:
+    """The all-zero charger id is explicitly ignored."""
+    inst, charger = _installation_with_charger()
+    inst.stream_update({"ChargerId": "00000000-0000-0000-0000-000000000000"})
+    charger.set_attributes.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+#   Zaptec mapping / registry + poll dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_zaptec_register_and_contains() -> None:
+    """register/unregister and __contains__ handle both ids and objects."""
+    zap, _ = _make_zaptec([])
+    charger = Charger({"Id": "c1"}, zap)
+
+    zap.register("c1", charger)
+    assert "c1" in zap  # by id (str)
+    assert charger in zap  # by object (ZaptecBase branch)
+    assert "nope" not in zap
+    assert object() not in zap  # arbitrary object -> not present
+
+    zap.unregister("c1")
+    assert "c1" not in zap
+
+
+def test_zaptec_register_duplicate_raises() -> None:
+    """Registering the same id twice raises."""
+    zap, _ = _make_zaptec([])
+    charger = Charger({"Id": "c1"}, zap)
+    zap.register("c1", charger)
+    with pytest.raises(ValueError, match="already registered"):
+        zap.register("c1", charger)
+
+
+def test_zaptec_qual_id_unknown_returns_id() -> None:
+    """qual_id returns the raw id for an unknown object."""
+    zap, _ = _make_zaptec([])
+    assert zap.qual_id("missing-id") == "missing-id"
+
+
+@pytest.mark.asyncio
+async def test_poll_dispatches_info_and_state() -> None:
+    """poll() calls poll_info/poll_state on the selected objects."""
+    zap, _ = _make_zaptec([])
+    obj = Mock()
+    obj.poll_info = AsyncMock()
+    obj.poll_state = AsyncMock()
+    zap.register("x", obj)
+
+    await zap.poll(["x"], info=True, state=True)
+    obj.poll_info.assert_awaited_once()
+    obj.poll_state.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_poll_unknown_object_raises() -> None:
+    """poll() raises for an unregistered object id."""
+    zap, _ = _make_zaptec([])
+    with pytest.raises(ValueError, match="not found"):
+        await zap.poll(["missing"])

--- a/tests/zaptec/test_api.py
+++ b/tests/zaptec/test_api.py
@@ -83,12 +83,12 @@ async def test_get_archived_sessions_live(zaptec_username: str, zaptec_password:
         page = await chargers[0].get_archived_sessions(
             from_time=now - timedelta(days=730), to_time=now, page_size=5
         )
-        assert "Sessions" in page
-        assert "HasMore" in page
-        if page["Sessions"]:
-            session = page["Sessions"][0]
-            assert "Id" in session
-            assert "StartDateTime" in session
+        assert "sessions" in page
+        assert "hasMore" in page
+        if page["sessions"]:
+            session = page["sessions"][0]
+            assert "id" in session
+            assert "startDateTime" in session
             _LOGGER.info("Sample archived session: %s", session)
 
 
@@ -752,7 +752,7 @@ async def test_authorize_charge_posts() -> None:
 @pytest.mark.asyncio
 async def test_get_archived_sessions_builds_params() -> None:
     """get_archived_sessions() sends ChargerId, PageSize, From, To and Cursor as query params."""
-    payload = {"Sessions": [], "Cursor": None, "HasMore": False}
+    payload = {"sessions": [], "cursor": None, "hasMore": False}
     zap, session = _make_zaptec([FakeResponse(HTTPStatus.OK, json_data=payload)])
     charger = Charger({"Id": "charger-1"}, zap, installation=None)
 
@@ -778,7 +778,7 @@ async def test_get_archived_sessions_builds_params() -> None:
 @pytest.mark.asyncio
 async def test_get_archived_sessions_omits_cursor_when_not_given() -> None:
     """Cursor is omitted from params when not given; From/To are always sent."""
-    payload = {"Sessions": [], "Cursor": None, "HasMore": False}
+    payload = {"sessions": [], "cursor": None, "hasMore": False}
     zap, session = _make_zaptec([FakeResponse(HTTPStatus.OK, json_data=payload)])
     charger = Charger({"Id": "charger-1"}, zap, installation=None)
 

--- a/tests/zaptec/test_api.py
+++ b/tests/zaptec/test_api.py
@@ -1,5 +1,6 @@
 """Tests for zaptec/api.py."""
 
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 import json
 import logging
@@ -7,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import aiohttp
+from homeassistant.util import dt as dt_util
 import pytest
 
 from custom_components.zaptec.zaptec.api import Charger, Installation, Zaptec, ZaptecBase
@@ -54,6 +56,40 @@ async def test_api(zaptec_username: str, zaptec_password: str) -> None:
         # Print all the attributes.
         for obj in zaptec.objects():
             _LOGGER.info(obj.asdict())
+
+
+@pytest.mark.asyncio
+async def test_get_archived_sessions_live(zaptec_username: str, zaptec_password: str) -> None:
+    """Smoke-test the real field casing of /api/sessions/archived.
+
+    Skipped in CI and when SKIP_ZAPTEC_API_TEST=true, same as test_api above.
+    Run this manually against a real account at least once: swagger.json
+    *declares* this endpoint's fields in camelCase, but every other Zaptec
+    endpoint actually returns PascalCase despite the same swagger mismatch
+    (see validate.py's Charger/Installation models vs swagger's
+    ChargerListModel). If this test fails after fixing obvious typos, the
+    casing assumption in validate.py/statistics.py needs correcting. It will
+    also surface a 403 here if the test account lacks the Owner role this
+    endpoint requires - that's expected for non-Owner accounts, not a bug.
+    """
+    async with Zaptec(zaptec_username, zaptec_password) as zaptec:
+        await zaptec.login()
+        await zaptec.build()
+        chargers = list(zaptec.chargers)
+        if not chargers:
+            pytest.skip("Account has no chargers to test against")
+
+        now = dt_util.utcnow()
+        page = await chargers[0].get_archived_sessions(
+            from_time=now - timedelta(days=730), to_time=now, page_size=5
+        )
+        assert "Sessions" in page
+        assert "HasMore" in page
+        if page["Sessions"]:
+            session = page["Sessions"][0]
+            assert "Id" in session
+            assert "StartDateTime" in session
+            _LOGGER.info("Sample archived session: %s", session)
 
 
 # ===========================================================================
@@ -711,6 +747,52 @@ async def test_authorize_charge_posts() -> None:
     method, url, _ = session.calls[-1]
     assert method == "post"
     assert url.endswith("chargers/c1/authorizecharge")
+
+
+@pytest.mark.asyncio
+async def test_get_archived_sessions_builds_params() -> None:
+    """get_archived_sessions() sends ChargerId, PageSize, From, To and Cursor as query params."""
+    payload = {"Sessions": [], "Cursor": None, "HasMore": False}
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.OK, json_data=payload)])
+    charger = Charger({"Id": "charger-1"}, zap, installation=None)
+
+    result = await charger.get_archived_sessions(
+        from_time=datetime(2026, 1, 1, tzinfo=UTC),
+        to_time=datetime(2026, 1, 2, tzinfo=UTC),
+        cursor="abc",
+    )
+
+    assert result == payload
+    method, url, kwargs = session.calls[0]
+    assert method == "get"
+    assert url == "https://api.zaptec.com/api/sessions/archived"
+    assert kwargs["params"] == {
+        "ChargerId": "charger-1",
+        "PageSize": 200,
+        "From": "2026-01-01T00:00:00+00:00",
+        "To": "2026-01-02T00:00:00+00:00",
+        "Cursor": "abc",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_archived_sessions_omits_cursor_when_not_given() -> None:
+    """Cursor is omitted from params when not given; From/To are always sent."""
+    payload = {"Sessions": [], "Cursor": None, "HasMore": False}
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.OK, json_data=payload)])
+    charger = Charger({"Id": "charger-1"}, zap, installation=None)
+
+    await charger.get_archived_sessions(
+        from_time=datetime(2026, 1, 1, tzinfo=UTC),
+        to_time=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+
+    assert session.calls[0][2]["params"] == {
+        "ChargerId": "charger-1",
+        "PageSize": 200,
+        "From": "2026-01-01T00:00:00+00:00",
+        "To": "2026-01-02T00:00:00+00:00",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/zaptec/test_api.py
+++ b/tests/zaptec/test_api.py
@@ -253,6 +253,98 @@ async def test_request_timeout_retried_then_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
+#   Transient HTTP status retry (429/502/503/504) — issue #392
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status",
+    [
+        HTTPStatus.TOO_MANY_REQUESTS,
+        HTTPStatus.BAD_GATEWAY,
+        HTTPStatus.SERVICE_UNAVAILABLE,
+        HTTPStatus.GATEWAY_TIMEOUT,
+    ],
+)
+async def test_request_transient_status_retries_then_succeeds(status: HTTPStatus) -> None:
+    """A transient server status is retried, and a later 200 is returned."""
+    payload = {"value": "ok"}
+    zap, session = _make_zaptec(
+        [FakeResponse(status), FakeResponse(HTTPStatus.OK, json_data=payload)],
+        max_time=0.001,
+    )
+    result = await zap.request("unregistered/url")
+    assert result == payload
+    assert len(session.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_request_transient_status_on_post_retries() -> None:
+    """Unlike 500, a transient 503 is retried even for POST (infra-level error)."""
+    zap, session = _make_zaptec(
+        [FakeResponse(HTTPStatus.SERVICE_UNAVAILABLE), FakeResponse(HTTPStatus.NO_CONTENT)],
+        max_time=0.001,
+    )
+    result = await zap.request("unregistered/url", method="post")
+    assert result == b""
+    assert len(session.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_request_persistent_503_raises_request_error_with_code() -> None:
+    """A persistent 503 is retried to exhaustion, then raises RequestError(503)."""
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.SERVICE_UNAVAILABLE)], max_time=0.001)
+    with pytest.raises(RequestError) as excinfo:
+        await zap.request("unregistered/url")
+    assert excinfo.value.error_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert len(session.calls) == API_RETRIES
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_retries_transient_then_succeeds() -> None:
+    """A transient 503 on the token endpoint is retried instead of failing setup."""
+    zap, session = _make_zaptec(
+        [
+            FakeResponse(HTTPStatus.SERVICE_UNAVAILABLE),
+            FakeResponse(HTTPStatus.OK, json_data={"access_token": "abc"}),
+        ],
+        max_time=0.001,
+    )
+    await zap.login()
+    assert len(session.calls) == 2
+    await zap.request("some/url")
+    _, _, kwargs = session.calls[-1]
+    assert kwargs["headers"]["Authorization"] == "Bearer abc"
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_persistent_503_raises_request_error() -> None:
+    """A persistent 503 on the token endpoint eventually raises RequestError(503)."""
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.SERVICE_UNAVAILABLE)], max_time=0.001)
+    with pytest.raises(RequestError) as excinfo:
+        await zap.login()
+    assert excinfo.value.error_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert len(session.calls) == API_RETRIES
+
+
+@pytest.mark.asyncio
+async def test_retry_after_header_is_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Retry-After header sets the next backoff delay for a transient status."""
+    sleep = AsyncMock()
+    monkeypatch.setattr("custom_components.zaptec.zaptec.api.asyncio.sleep", sleep)
+    zap, _ = _make_zaptec(
+        [
+            FakeResponse(HTTPStatus.SERVICE_UNAVAILABLE, headers={"Retry-After": "2"}),
+            FakeResponse(HTTPStatus.OK, json_data={"ok": True}),
+        ],
+    )
+    await zap.request("unregistered/url")
+    slept = [call.args[0] for call in sleep.await_args_list]
+    assert 2.0 in slept
+
+
+# ---------------------------------------------------------------------------
 #   ZaptecBase.state_to_attrs
 # ---------------------------------------------------------------------------
 

--- a/tests/zaptec/test_api.py
+++ b/tests/zaptec/test_api.py
@@ -24,6 +24,11 @@ from custom_components.zaptec.zaptec.zconst import ZCONST
 
 _LOGGER = logging.getLogger(__name__)
 
+# One retry means the request was attempted twice (one failure, one success).
+CALLS_AFTER_ONE_RETRY = 2
+# The Retry-After header value (seconds) used in the transient-status tests.
+RETRY_AFTER_SECONDS = 2.0
+
 
 @pytest.mark.asyncio
 async def test_api(zaptec_username: str, zaptec_password: str) -> None:
@@ -276,7 +281,7 @@ async def test_request_transient_status_retries_then_succeeds(status: HTTPStatus
     )
     result = await zap.request("unregistered/url")
     assert result == payload
-    assert len(session.calls) == 2
+    assert len(session.calls) == CALLS_AFTER_ONE_RETRY
 
 
 @pytest.mark.asyncio
@@ -288,7 +293,7 @@ async def test_request_transient_status_on_post_retries() -> None:
     )
     result = await zap.request("unregistered/url", method="post")
     assert result == b""
-    assert len(session.calls) == 2
+    assert len(session.calls) == CALLS_AFTER_ONE_RETRY
 
 
 @pytest.mark.asyncio
@@ -312,7 +317,7 @@ async def test_refresh_token_retries_transient_then_succeeds() -> None:
         max_time=0.001,
     )
     await zap.login()
-    assert len(session.calls) == 2
+    assert len(session.calls) == CALLS_AFTER_ONE_RETRY
     await zap.request("some/url")
     _, _, kwargs = session.calls[-1]
     assert kwargs["headers"]["Authorization"] == "Bearer abc"
@@ -341,7 +346,7 @@ async def test_retry_after_header_is_honored(monkeypatch: pytest.MonkeyPatch) ->
     )
     await zap.request("unregistered/url")
     slept = [call.args[0] for call in sleep.await_args_list]
-    assert 2.0 in slept
+    assert RETRY_AFTER_SECONDS in slept
 
 
 # ---------------------------------------------------------------------------

--- a/tests/zaptec/test_api.py
+++ b/tests/zaptec/test_api.py
@@ -12,6 +12,7 @@ import pytest
 from custom_components.zaptec.zaptec.api import Charger, Installation, Zaptec, ZaptecBase
 from custom_components.zaptec.zaptec.const import API_RETRIES
 from custom_components.zaptec.zaptec.exceptions import (
+    AuthenticationError,
     RequestConnectionError,
     RequestDataError,
     RequestError,
@@ -503,3 +504,375 @@ async def test_poll_unknown_object_raises() -> None:
     zap, _ = _make_zaptec([])
     with pytest.raises(ValueError, match="not found"):
         await zap.poll(["missing"])
+
+
+# ---------------------------------------------------------------------------
+#   Charger command / settings wrappers
+# ---------------------------------------------------------------------------
+
+
+def _charger_with_session(
+    outcomes: list[FakeResponse | BaseException],
+) -> tuple[Charger, FakeSession]:
+    """Build a charger whose owner performs requests against a FakeSession."""
+    zap, session = _make_zaptec(outcomes)
+    return Charger({"Id": "c1"}, zap), session
+
+
+def _installation_with_session(
+    outcomes: list[FakeResponse | BaseException],
+) -> tuple[Installation, FakeSession]:
+    """Build an installation whose owner performs requests against a FakeSession."""
+    zap, session = _make_zaptec(outcomes)
+    return Installation({"Id": "i1"}, zap), session
+
+
+@pytest.mark.asyncio
+async def test_command_posts_to_send_command_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A named command resolves to its id and POSTs to SendCommand."""
+    monkeypatch.setattr(ZCONST, "commands", {"restart_charger": 102}, raising=False)
+    charger, session = _charger_with_session([FakeResponse(HTTPStatus.OK, json_data={})])
+
+    await charger.command("restart_charger")
+
+    method, url, _ = session.calls[-1]
+    assert method == "post"
+    assert url.endswith("chargers/c1/SendCommand/102")
+
+
+@pytest.mark.asyncio
+async def test_command_authorize_charge_alias() -> None:
+    """The authorize_charge alias POSTs to the authorizecharge endpoint."""
+    charger, session = _charger_with_session([FakeResponse(HTTPStatus.OK, json_data={})])
+
+    await charger.command("authorize_charge")
+
+    method, url, _ = session.calls[-1]
+    assert method == "post"
+    assert url.endswith("chargers/c1/authorizecharge")
+
+
+@pytest.mark.asyncio
+async def test_command_unknown_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unknown command raises without issuing a request."""
+    monkeypatch.setattr(ZCONST, "commands", {}, raising=False)
+    charger, session = _charger_with_session([])
+
+    with pytest.raises(ValueError, match="Unknown command"):
+        await charger.command("does_not_exist")
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_set_settings_valid() -> None:
+    """Valid settings are POSTed to the charger update endpoint."""
+    settings = {"maxChargeCurrent": 16}
+    charger, session = _charger_with_session([FakeResponse(HTTPStatus.OK, json_data={})])
+
+    await charger.set_settings(settings)
+
+    method, url, kwargs = session.calls[-1]
+    assert method == "post"
+    assert url.endswith("chargers/c1/update")
+    assert kwargs["json"] == settings
+
+
+@pytest.mark.asyncio
+async def test_set_settings_unknown_key_raises() -> None:
+    """An unknown setting key raises without issuing a request."""
+    charger, session = _charger_with_session([])
+    with pytest.raises(ValueError, match="Unknown setting"):
+        await charger.set_settings({"bogusKey": 1})
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_authorize_charge_posts() -> None:
+    """authorize_charge POSTs to the authorizecharge endpoint."""
+    charger, session = _charger_with_session([FakeResponse(HTTPStatus.OK, json_data={})])
+
+    await charger.authorize_charge()
+
+    method, url, _ = session.calls[-1]
+    assert method == "post"
+    assert url.endswith("chargers/c1/authorizecharge")
+
+
+@pytest.mark.asyncio
+async def test_set_permanent_cable_lock_payload() -> None:
+    """The permanent cable lock is sent under Cable.PermanentLock."""
+    expected = {"Cable": {"PermanentLock": True}}
+    charger, session = _charger_with_session([FakeResponse(HTTPStatus.OK, json_data={})])
+
+    await charger.set_permanent_cable_lock(lock=True)
+
+    method, url, kwargs = session.calls[-1]
+    assert method == "post"
+    assert url.endswith("chargers/c1/localSettings")
+    assert kwargs["json"] == expected
+
+
+@pytest.mark.asyncio
+async def test_set_hmi_brightness_payload() -> None:
+    """The HMI brightness is sent under Device.HmiBrightness."""
+    brightness = 0.5
+    expected = {"Device": {"HmiBrightness": brightness}}
+    charger, session = _charger_with_session([FakeResponse(HTTPStatus.OK, json_data={})])
+
+    await charger.set_hmi_brightness(brightness)
+
+    method, url, kwargs = session.calls[-1]
+    assert method == "post"
+    assert url.endswith("chargers/c1/localSettings")
+    assert kwargs["json"] == expected
+
+
+# ---------------------------------------------------------------------------
+#   Installation current-limit setters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_limit_current_available_current() -> None:
+    """A single availableCurrent limit is POSTed to the installation update."""
+    expected = {"availableCurrent": 16}
+    inst, session = _installation_with_session([FakeResponse(HTTPStatus.OK, json_data={})])
+
+    await inst.set_limit_current(**expected)
+
+    method, url, kwargs = session.calls[-1]
+    assert method == "post"
+    assert url.endswith("installation/i1/update")
+    assert kwargs["json"] == expected
+
+
+@pytest.mark.asyncio
+async def test_set_limit_current_requires_current_argument() -> None:
+    """Calling without any current argument raises."""
+    inst, session = _installation_with_session([])
+    with pytest.raises(ValueError, match="availableCurrent"):
+        await inst.set_limit_current()
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_set_limit_current_partial_phases_raise() -> None:
+    """Providing availableCurrent with only some per-phase currents raises."""
+    inst, session = _installation_with_session([])
+    with pytest.raises(ValueError, match="all of them must be set"):
+        await inst.set_limit_current(availableCurrent=10, availableCurrentPhase1=10)
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_set_limit_current_out_of_range_raises() -> None:
+    """A current above the installation maximum raises."""
+    inst, session = _installation_with_session([])
+    with pytest.raises(ValueError, match="between 0 and"):
+        await inst.set_limit_current(availableCurrent=1000)
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_set_three_to_one_phase_switch_current() -> None:
+    """The 3-to-1 phase switch current is POSTed to the installation update."""
+    current = 16
+    expected = {"threeToOnePhaseSwitchCurrent": current}
+    inst, session = _installation_with_session([FakeResponse(HTTPStatus.OK, json_data={})])
+
+    await inst.set_three_to_one_phase_switch_current(current)
+
+    method, url, kwargs = session.calls[-1]
+    assert method == "post"
+    assert url.endswith("installation/i1/update")
+    assert kwargs["json"] == expected
+
+
+@pytest.mark.asyncio
+async def test_set_three_to_one_phase_switch_current_out_of_range_raises() -> None:
+    """An out-of-range 3-to-1 phase switch current raises."""
+    inst, session = _installation_with_session([])
+    with pytest.raises(ValueError, match="between 0 and"):
+        await inst.set_three_to_one_phase_switch_current(1000)
+    assert session.calls == []
+
+
+# ---------------------------------------------------------------------------
+#   Charger.poll_info / poll_state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_info_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """poll_info fetches the charger and applies the attributes."""
+    # Payload validation has its own tests; bypass it here.
+    monkeypatch.setattr("custom_components.zaptec.zaptec.api.validate", Mock())
+    charger, _ = _charger_with_session([FakeResponse(HTTPStatus.OK, json_data={"Id": "c1"})])
+    charger.set_attributes = Mock()
+
+    await charger.poll_info()
+
+    charger.set_attributes.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_poll_info_falls_back_to_charger_list_on_forbidden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 403 on the charger endpoint falls back to the chargers list."""
+    monkeypatch.setattr("custom_components.zaptec.zaptec.api.validate", Mock())
+    charger, _ = _charger_with_session(
+        [
+            FakeResponse(HTTPStatus.FORBIDDEN),
+            FakeResponse(HTTPStatus.OK, json_data={"Data": [{"Id": "c1", "Name": "x"}]}),
+        ]
+    )
+    charger.set_attributes = Mock()
+
+    await charger.poll_info()
+
+    # Reached only via the fallback branch, since the first request raised.
+    charger.set_attributes.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_poll_info_non_forbidden_error_propagates() -> None:
+    """A non-403 error is re-raised rather than falling back."""
+    charger, _ = _charger_with_session([FakeResponse(HTTPStatus.NOT_FOUND)])
+    with pytest.raises(RequestError):
+        await charger.poll_info()
+
+
+@pytest.mark.asyncio
+async def test_poll_state_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """poll_state fetches the state list and applies the mapped attributes."""
+    monkeypatch.setattr(ZCONST, "observations", {"1": "current"}, raising=False)
+    monkeypatch.setattr("custom_components.zaptec.zaptec.api.validate", Mock())
+    charger, session = _charger_with_session(
+        [FakeResponse(HTTPStatus.OK, json_data=[{"StateId": "1", "ValueAsString": "5"}])]
+    )
+    charger.set_attributes = Mock()
+
+    await charger.poll_state()
+
+    _, url, _ = session.calls[-1]
+    assert url.endswith("chargers/c1/state")
+    charger.set_attributes.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_poll_state_forbidden_is_ignored() -> None:
+    """A 403 on the state endpoint is swallowed (no attribute update)."""
+    charger, _ = _charger_with_session([FakeResponse(HTTPStatus.FORBIDDEN)])
+    charger.set_attributes = Mock()
+
+    await charger.poll_state()
+
+    charger.set_attributes.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+#   Zaptec._refresh_token / login
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_stores_and_uses_access_token() -> None:
+    """A successful login obtains a token and sends it on later requests."""
+    zap, session = _make_zaptec(
+        [
+            FakeResponse(HTTPStatus.OK, json_data={"access_token": "abc"}),
+            FakeResponse(HTTPStatus.OK, json_data={}),
+        ]
+    )
+
+    await zap.login()
+    await zap.request("some/url")
+
+    _, _, kwargs = session.calls[-1]
+    assert kwargs["headers"]["Authorization"] == "Bearer abc"
+
+
+@pytest.mark.asyncio
+async def test_login_bad_credentials_raises_authentication_error() -> None:
+    """A 400 from the token endpoint raises AuthenticationError."""
+    zap, _ = _make_zaptec(
+        [FakeResponse(HTTPStatus.BAD_REQUEST, json_data={"error_description": "nope"})]
+    )
+    with pytest.raises(AuthenticationError):
+        await zap.login()
+
+
+# ---------------------------------------------------------------------------
+#   Assorted small accessors / lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_command_by_numeric_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A numeric command id is sent directly to SendCommand."""
+    monkeypatch.setattr(ZCONST, "commands", {102: "restart_charger"}, raising=False)
+    charger, session = _charger_with_session([FakeResponse(HTTPStatus.OK, json_data={})])
+
+    await charger.command(102)
+
+    _, url, _ = session.calls[-1]
+    assert url.endswith("chargers/c1/SendCommand/102")
+
+
+@pytest.mark.asyncio
+async def test_installation_poll_info_strips_logo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """poll_info removes the bulky SupportGroup logo before storing attributes."""
+    monkeypatch.setattr("custom_components.zaptec.zaptec.api.validate", Mock())
+    inst, _ = _installation_with_session(
+        [FakeResponse(HTTPStatus.OK, json_data={"SupportGroup": {"LogoBase64": "AAAA"}})]
+    )
+    inst.set_attributes = Mock()
+
+    await inst.poll_info()
+
+    inst.set_attributes.assert_called_once()
+    stored = inst.set_attributes.call_args[0][0]
+    assert stored["SupportGroup"]["LogoBase64"].startswith("<Removed")
+
+
+def test_charger_is_charging() -> None:
+    """is_charging reflects the operation mode."""
+    assert Charger({"ChargerOperationMode": "Connected_Charging"}, _fake_owner()).is_charging()
+    assert not Charger({"ChargerOperationMode": "Disconnected"}, _fake_owner()).is_charging()
+
+
+def test_charger_model_from_device_id() -> None:
+    """The model is derived from the DeviceId prefix."""
+    chg = Charger({"DeviceId": "ZAP123456"}, _fake_owner())
+    assert chg.model_prefix == "ZAP"
+    assert chg.model == "Zaptec Go"
+
+
+def test_zaptec_collections_and_accessors() -> None:
+    """objects/installations/chargers and iteration reflect the registry."""
+    zap, _ = _make_zaptec([])
+    inst = Installation({"Id": "i1"}, zap)
+    chg = Charger({"Id": "c1"}, zap)
+    zap.register("i1", inst)
+    zap.register("c1", chg)
+
+    ids = {"i1", "c1"}
+    assert set(zap) == ids  # __iter__
+    assert len(zap) == len(ids)  # __len__
+    # ZaptecBase subclasses Mapping (unhashable), so compare as lists.
+    objs = list(zap.objects())
+    assert inst in objs
+    assert chg in objs
+    assert list(zap.installations) == [inst]
+    assert list(zap.chargers) == [chg]
+
+    zap.unregister("c1")
+    assert set(zap) == {"i1"}
+
+
+@pytest.mark.asyncio
+async def test_zaptec_async_context_manager_closes_internal_client() -> None:
+    """Entering/exiting the context manager works with an internally-created client."""
+    async with Zaptec("user", "pass") as zap:
+        assert isinstance(zap, Zaptec)

--- a/tests/zaptec/test_api.py
+++ b/tests/zaptec/test_api.py
@@ -175,6 +175,24 @@ async def test_request_ok_returns_json() -> None:
 
 
 @pytest.mark.asyncio
+async def test_request_passes_params_to_session() -> None:
+    """Query params are forwarded to the underlying session.request() call."""
+    payload = {"value": "answer"}
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.OK, json_data=payload)])
+    await zap.request("unregistered/url", params={"Foo": "bar", "PageSize": 200})
+    assert session.calls[0][2]["params"] == {"Foo": "bar", "PageSize": 200}
+
+
+@pytest.mark.asyncio
+async def test_request_omits_params_when_not_given() -> None:
+    """No params kwarg is passed to session.request() when none are given."""
+    payload = {"value": "answer"}
+    zap, session = _make_zaptec([FakeResponse(HTTPStatus.OK, json_data=payload)])
+    await zap.request("unregistered/url")
+    assert "params" not in session.calls[0][2]
+
+
+@pytest.mark.asyncio
 async def test_request_no_content_returns_bytes() -> None:
     """A 204/201 response returns the raw body bytes."""
     zap, _ = _make_zaptec([FakeResponse(HTTPStatus.NO_CONTENT, read_data=b"done")])


### PR DESCRIPTION
## ⚠️ Stacked on #391, #393, #394, #395

This branch is based on my fork's `master`, which already includes #391, #393, #394, and #395 (all currently open, not yet merged upstream). Until those merge, this PR's diff will show all of their commits too. **Please merge #391 → #393 → #394 → #395 first** (in that order, as each stacks on the previous) — this PR's diff will then automatically shrink to just the 15 commits that are actually new here. I'm opening it now rather than waiting so it's visible/reviewable in parallel; happy to rebase once the others land if that's preferred.

## Summary

Fixes #300 by giving each tracked charger a **second, independent statistics feed** for the Energy Dashboard — sourced from Zaptec's own archived (completed) charge-session history via `/api/sessions/archived`, rather than from live polling of the charger's state.

The existing `Energy Meter` sensor's hourly statistics are built from whatever value the sensor happens to hold each time Home Assistant polls it — so consumption that happens near the end of an hour, or during a period of slow/delayed polling, gets attributed to the *next* hour instead. This is issue #300 (and the older #162): the Energy Dashboard shows real usage up to an hour later than it actually happened, and there's no way to fix that from the live sensor alone, since by the time HA polls it the information about *when within that hour* the energy was used is already lost.

Zaptec's cloud backend, however, already knows exactly when each session's energy was consumed — it exposes per-session hourly-ish meter checkpoints via `energyDetails` on `GET /api/sessions/archived`. This PR imports that data directly into Home Assistant's long-term statistics store as a new external statistic (`zaptec:energy_<charger id>`), which shows up in the Energy Dashboard's source picker as **"`<charger name>` Energy"**. It runs independently of the integration's existing live-state coordinators, polls hourly, and backfills up to 2 years of history on first run.

## Why an external statistic instead of fixing the existing sensor

The `Energy Meter` sensor's *live* value is still exactly what it should be — a real-time cumulative meter reading. The dashboard's hour-misattribution is purely a byproduct of *when HA happens to poll it*, not something a sensor definition change can fix in general. Home Assistant's own external statistics API exists precisely for this: a way to backfill *correctly-timed* historical statistics from an authoritative external source (the cloud's own session archive) without needing a live entity behind it at all — the same pattern integrations like Opower use for cost statistics. This also sidesteps the documented "Adjust sum" workaround needed today when using _Session total charge_ as a stand-in.

## What's implemented

- **`Zaptec.request()`** gained a `params` kwarg for query-string support (needed for the new endpoint's `From`/`To`/`Cursor`/`PageSize` params).
- **`Charger.get_archived_sessions()`** — cursor-paginated client for `/api/sessions/archived`, filtered by session *end* time (per the endpoint's actual semantics, confirmed against the official docs, not just `swagger.json`, which is missing/wrong on several details for this endpoint).
- **`validate.py`** gained a permissive (`extra="allow"`) pydantic model for the endpoint's response, since several of its fields' exact shapes aren't documented and shouldn't hard-fail the whole page if unconfirmed.
- **`bucket_sessions_hourly()`** (`statistics.py`) — the core pure function: turns a session's `energyDetails` into hourly `StatisticData` points, chaining onto a running sum. This went through substantial revision based on live testing against a real account (see below) - it's more subtle than it looks:
  - Each `energyDetails` point's `energy` field is the *incremental delta* since the previous point, not a cumulative running total (confirmed by cross-checking a session's `energyDetails` against its own OCMF-signed `sessionSignature` meter readings - independently signed data, not just an assumption).
  - Zaptec reports on a fixed hourly schedule while a session has metering activity, but silently skips ticks while paused/idle - so gaps between reports can span many hours (confirmed: real gaps of 4 and 17 hours in live data). A delta following such a gap is attributed to the hour *immediately before* the report that closed the gap (confirmed against the charger's own power sensor - the real energy consistently landed there, not spread across the gap and not at its start), clamped so a session's real (irregularly-timed) *end* isn't walked back past the previous report's hour.
  - A small tolerance window absorbs clock/reporting jitter of a few seconds right at an hour boundary, so it stays correct regardless of firmware/device timing precision - not just for the one device this was tested against.
  - Voided/aborted sessions are skipped (no meaningful energy, per the API docs). Sessions without `energyDetails` (pre-3.2 firmware) fall back to a single point at `endDateTime` using the session's total `energy`.
- **`ZaptecStatisticsCoordinator`** (`statistics.py`) — a `DataUpdateCoordinator` per charger, independent of the existing live-state coordinators so a failure here (e.g. a non-Owner account getting a 403, since this endpoint requires the Owner role) degrades only this one feed rather than the whole integration. Uses `async_refresh()` (not `async_config_entry_first_refresh()`) for the same reason. Resumes from `get_last_statistics()` on every poll rather than re-scanning all history.
- Wired into `manager.py`/`__init__.py`: one coordinator per tracked `Charger`, refreshed alongside the existing device coordinators.
- README updated to point users at the new "`<charger name>` Energy" statistic instead of the documented `Energy Meter`/`Session total charge` workaround.

## Testing

- Extensive unit tests for `bucket_sessions_hourly()` covering hour-bucketing, the resume/`after`-cutoff logic (including a regression test for a double-counting bug caught during review), voided/aborted skipping, the legacy fallback path, the multi-hour-gap attribution rule, and the session-end clamping edge case.
- Unit tests for `ZaptecStatisticsCoordinator` covering first-run backfill, resume, pagination, the 403/Owner-role soft-skip vs. hard-fail distinction, and HA-version compatibility for the `unit_class` metadata field (present in newer HA core, absent before).
- **Live-tested against a real account and charger** over several iterations, each surfacing and fixing a real issue that unit tests alone couldn't have caught:
  - The endpoint genuinely returns `camelCase` fields, unlike every other Zaptec endpoint's `PascalCase` (confirmed via a live `ValidationError`).
  - Older HA core versions (tested against 2025.10.2) don't have the `unit_class` statistics-metadata field at all; newer ones increasingly require it - handled with runtime feature detection instead of a hard version pin.
  - The `energyDetails`-is-a-delta and gap-attribution findings above, confirmed by diffing real archived-session data against both the session's own OCMF-signed meter readings and the charger's independent live power sensor.
  - Cross-checked the final result against an existing utility-meter-based tracker on the same charger and the raw power sensor as ground truth, for two full days of real usage, before considering this ready.

## Test plan for reviewers

- [ ] `SKIP_ZAPTEC_API_TEST=true pytest tests -q` passes (233 tests, plus 3 skipped needing live credentials)
- [ ] `ruff format --diff` and `ruff check` clean on all touched files
- [ ] After merging, verify a real charger's "`<charger name>` Energy" statistic appears in Settings → Dashboards → Energy → Add Consumption, and that a non-Owner account gets a clear warning log instead of a setup failure
