### PR TITLE
fix: force OS DNS resolver in zaptec_constants test fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 
+import aiohttp
 import pytest
 
 from custom_components.zaptec.zaptec.api import Zaptec
@@ -59,7 +60,12 @@ def zaptec_constants() -> dict:
     """Get latest constants from Zaptec API."""
 
     async def get_zaptec_constants() -> dict:
-        async with Zaptec("N/A", "N/A") as zaptec:
+        # aiohttp defaults to aiodns/pycares (AsyncResolver) whenever they're
+        # importable, which bypasses the OS resolver stack and fails to
+        # contact DNS in this dev environment. Force the OS-backed resolver.
+        connector = aiohttp.TCPConnector(resolver=aiohttp.resolver.ThreadedResolver())
+        client = aiohttp.ClientSession(connector=connector)
+        async with Zaptec("N/A", "N/A", client=client) as zaptec:
             # the constants API endpoint does not require login
             const: dict = await zaptec.request("constants")
             return const


### PR DESCRIPTION
## Summary
- `aiohttp.ClientSession()` auto-switches to `aiodns`/`pycares`'s `AsyncResolver` whenever those packages are importable, bypassing the OS resolver stack
- In some dev environments (e.g. native Windows without a working async DNS path) that resolver can't reach DNS (`Could not contact DNS servers`), even though OS-backed lookups (`urllib`, `ThreadedResolver`) work fine from the same shell
- This makes the `zaptec_constants` fixture fail regardless of `SKIP_ZAPTEC_API_TEST`, taking down `tests/zaptec/test_zconst.py` and `tests/zaptec/test_redact.py`
- Fix: force `aiohttp.resolver.ThreadedResolver()` via an explicit `TCPConnector` for the fixture's `Zaptec` client — no behavior change when `aiodns` isn't installed, and no change to what's actually tested

## Test plan
- [x] `pytest tests/zaptec/test_zconst.py tests/zaptec/test_redact.py -q` — 23 passed (previously errored in the affected environment)
- [x] `pytest tests -q` — 231 passed, 2 skipped
- [x] `ruff format --diff` / `ruff check` clean on `tests/conftest.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)