### PR TITLE
Use requirements.txt for ruff version in ci-pipeline

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -48,14 +48,7 @@ jobs:
       - name: Run ruff check
         uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
-          args: check --exit-zero # succeed despite errors until https://github.com/custom-components/zaptec/issues/258 is done
-          src: "."
-          version-file: "requirements.txt"
-
-      - name: Run strict ruff check (except api.py)
-        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
-        with:
-          args: check --exclude custom_components/zaptec/zaptec/api.py
+          args: check
           src: "."
           version-file: "requirements.txt"
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -43,18 +43,21 @@ jobs:
         with:
           args: format --diff
           src: "."
+          version-file: "requirements.txt"
 
       - name: Run ruff check
         uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
           args: check --exit-zero # succeed despite errors until https://github.com/custom-components/zaptec/issues/258 is done
           src: "."
+          version-file: "requirements.txt"
 
       - name: Run strict ruff check (except api.py)
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
           args: check --exclude custom_components/zaptec/zaptec/api.py
           src: "."
+          version-file: "requirements.txt"
 
   manifest-requirements:
     name: Manifest requirements validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 colorlog==6.10.1
 homeassistant==2026.4.3
 pip>=25.0
-ruff==0.15.9
+ruff==0.15.22
 
 # Copy from manifest.json to get this into the dev container
 # without needing to start HA


### PR DESCRIPTION
Quickfix for #406 by using requirements.txt to define ruff version in ci-pipeline instead of pyproject.toml.

Also remove workaround for api.py, since there are no errors left.