### PR TITLE
Add AI policy derived from HA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ $RECYCLE.BIN/
 venv*/
 .venv*/
 /.python-version
+uv.lock
+
+# Development environments
+.devcontainer-lock.json
 
 # Zaptec files
 constant.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# GitHub Copilot & Claude Code Instructions
+
+This repository contains a Home Assistant integration for the Zaptec Electric Vehicle Chargers (EVC).
+
+The integration runs on Home Assistant, which is a python 3 ecosystem. These guidelines are based on [Home Assistant's AGENTS.md](https://github.com/home-assistant/core/blob/dev/AGENTS.md) with some modifications to fit this project. This project is not a formal part of Home Assistant or the Open Home Foundation (which is the organization behind Home Assistant), but the Home Assistant guidelines also applies to this project.
+
+## General
+
+- Read DEVELOPMENT.md for instructions that must be followed
+- Follow the Home Assistant quality scale rating with no lower than Gold level. See https://developers.home-assistant.io/docs/core/integration-quality-scale/rules
+
+## Git Commit Guidelines
+
+- **Do NOT amend, squash, or rebase commits that have already been pushed to the PR branch after the PR is opened** - Reviewers need to follow the commit history, as well as see what changed since their last review
+
+## Pull Requests
+
+## Development Commands
+
+- Run "python3" in current virtual environment to ensure the correct Python version is used for testing.
+- When entering a new environment or worktree, run `scripts/setup` to set up the virtual environment with all development dependencies (pylint, pre-commit hooks, etc.). This is required before committing. If uv reports that no download was found for the required Python version, the environment is running an outdated version of uv; upgrade it with `curl -LsSf https://astral.sh/uv/install.sh | sh` and run `script/setup` again.
+- After finishing a code session, run `uv run prek run --all-files` to check for linting and formatting issues.
+
+## Python Syntax Notes
+
+- Home Assistant officially supports Python 3.14 as its minimum version. Do not flag syntax or features that require Python 3.14 as issues, and do not suggest workarounds for older Python versions.
+- Python 3.14 explicitly allows `except TypeA, TypeB:` without parentheses. Never flag this as an issue.
+- Python 3.14 evaluates annotations lazily (PEP 649). Forward references in annotations do not need to be quoted — annotations can reference names defined later in the module without quoting them or using `from __future__ import annotations`. Do not flag unquoted forward references in annotations as issues.
+
+## Testing
+
+- Use `uv run pytest` to run tests
+- When writing or modifying tests, ensure all test function parameters have type annotations.
+- Prefer concrete types (for example, `HomeAssistant`, `MockConfigEntry`, etc.) over `Any`.
+- Prefer `@pytest.mark.usefixtures` over arguments, if the argument is not going to be used.
+- Avoid using conditions/branching in tests. Instead, either split tests or adjust the test parametrization to cover all cases without branching.
+- If multiple tests share most of their code, use `pytest.mark.parametrize` to merge them into a single parameterized test instead of duplicating the body. Use `pytest.param` with an `id` parameter to name the test cases clearly.
+- Hardcoded `entity_id`s in tests are fine. If the same one is repeated, use a constant.
+
+## Good practices
+
+- When reviewing entity actions, do not suggest extra defensive checks for input fields that are already validated by Home Assistant's service/action schemas and entity selection filters. Suggest additional guards only when data bypasses those validators or is transformed into a less-safe form.
+- When validation guarantees a dict key exists, prefer direct key access (`data["key"]`) instead of `.get("key")` so contract violations are surfaced instead of silently masked.
+- Keep comments concise. Prefer one short line stating the non-obvious constraint, or no comment at all.
+- Do not add comments that just restate the code on the following line(s) (e.g. `# Check if initialized` above `if self.initialized:`). Comments should only explain why (non-obvious constraints, surprising behavior, or workarounds), never what. Never add comments that justify a change by referencing what the code looked like before. Comments in tests that explain why a function call or assertion is made are ok.
+- Do not add section or divider comments (e.g. `# --- XYZ Triggers ---`) inside or outside of functions, since those can easily become stale and be misleading.
+- When catching exceptions, try-clauses should be as small as possible, i.e. avoid wrapping large blocks of code in a try-clause, and avoid catching exceptions from functions that are not expected to raise them.
+
+## AI policy
+
+This project follows the [Zaptec Integration AI Policy](AI_POLICY.md).
+Autonomous contributions are not accepted: a human must review, understand,
+and be able to explain every change before it is submitted. Do not open
+issues or pull requests autonomously, and do not post comments on behalf of
+a user without their review.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,53 @@
+# AI Policy for the Zaptec integration
+
+The Zaptec integration is a community-driven component that is intended for use with Home Assistant. We believe it is advantageous to stay close to the guides and policies issues by the Open Home Foundation, which is the organization behind Home Assistant.
+
+Below is the verbatim copy of the Open Home Foundation. "we" in the following text means the Open Home Foundation. The Zaptec integration is not formally a part of the Open Home Foundation projects, but the same policies must be applied.
+
+---------------------------------------
+
+# Open Home Foundation - AI Policy
+
+We support using AI (i.e., LLMs) as tools when contributing to Open Home Foundation projects. However, you are responsible for any contributions you submit, and we are responsible for any contributions we merge and release. We hold a high bar for all contributions to our projects.
+
+Our maintainers dedicate their time and expertise to reviewing contributions. Submitting AI-generated content that you have not personally reviewed and understood wastes that time and will not be accepted.
+
+## Autonomous agents
+
+**We do not allow autonomous agents to be used for contributing to our projects.** We will close any pull requests or issues that we believe were created autonomously, and may mark automated comments as spam. This includes contributions that bypass the provided issue or pull request templates.
+
+## Communication on issues, pull requests, and code reviews
+
+We don't mind if you use AI tools to help you write. However, do not have tools post unreviewed content on your behalf. Keep responses to the minimum needed to communicate your intent. We may hide any comments that we believe are unreviewed AI output.
+
+If you are opening a pull request, we expect you to be able to explain the proposed changes in your own words. This includes the pull request description and responses to questions. If you use AI to help generate the pull request summary, you must review it for technical accuracy.
+
+**Do not use AI to generate answers to questions from maintainers.** You should understand and be able to explain your own work. Using AI to improve grammar or clarity is fine, but the substance of your responses must be your own.
+
+If you wish to include context from an interaction with AI in your comments, it must be in a quote block (e.g., using `>`) and disclosed as such. It must be accompanied by your own commentary explaining the relevance and implications of the context. Do not share long snippets.
+
+## Non-native English speakers
+
+We understand that AI is useful when communicating as a non-native English speaker. Using AI to improve the grammar or clarity of text you have written yourself is fine. If you are using AI to translate your comments, please ensure the translation accurately reflects your intent. Including your original text in a details block shows the effort behind your contribution, helps maintainers verify the translation if needed, and keeps the conversation readable.
+
+## Code and documentation contributions
+
+AI can be a helpful tool for writing code and documentation. However, due to the foundational open source nature of our projects, we require a human in the loop who understands the work produced by AI.
+
+All contributions must be reviewed and understood by the contributor before submission. You should be able to explain every change in a pull request you submit. Pull requests that appear to be unreviewed AI output will be closed without review.
+
+## Our use of AI
+
+Some of our projects use AI tools to assist with code reviews, issue triaging, reporting, and other project management tasks. These tools may leave comments on pull requests or issues. As with any automated tooling, these comments are not always correct.
+
+If an AI tool leaves a comment on your contribution, treat it as you would any other review comment. If you believe it is incorrect, say so; a brief explanation is sufficient. Maintainers always have the final say. If in doubt, ask a maintainer.
+
+## Enforcement
+
+Contributions that do not follow this policy will be closed. Repeated violations may result in being blocked from contributing to OHF projects. If you believe your contribution was closed in error, you are welcome to reach out to a maintainer to discuss.
+
+---
+
+The canonical version of this policy is published at
+<https://developers.home-assistant.io/docs/ai_policy>. In case of differences,
+the published version applies.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,6 +3,22 @@
 This document intends to contain various documentation and tips & tricks for
 developing the integration.
 
+## Project structure
+
+The project is divided into two major modules/libries
+
+- `custom_components/zaptec/zaptec/*.py` - This is the access library for
+  communicating with the Zaptec cloud services.
+
+   * Presents a Python API to the Zaptec cloud service
+   * The intent is to later be able to separate the library into a separate
+     and independent python package
+   * No Home Assistant specific code should be located here
+
+- `custom_components/zaptec/*.py` - Contains the Home Assistant integration
+   * The code should only access the Zaptec access library through its public
+     interface exported by `import .zaptec`.
+
 ## Guidelines
 
 This is a collection of guidelines that should be considered when working with:


### PR DESCRIPTION
Given the increasing amount of AI generated code in this project, its prudent that we get some guidelines established. That is not to say that we shouldn't be using AI/LLMs, but some boundaries are needed. Since this Zaptec integration is specifically built for HA, I believe its beneficial for us to use and mirror the policies from the Open Home Foundation (the org behind Home Assistant).

This PR introduces an AI policy and creates an `AGENTS.md` file to assist AI assisted development.

I have edited and reviewed these based on what I consider fair, but I'm very open to feedback, discussions and adjustments. Since this is fairly important for all of us I'm really grateful for any opinions we can get.

@steinmn and @rhammen I'd like your take on this PR please.