### PR TITLE
Enforce a 6A minimum on charger_min_current

### DIFF
--- a/custom_components/zaptec/number.py
+++ b/custom_components/zaptec/number.py
@@ -22,6 +22,8 @@ from .zaptec import Charger, Installation, ZaptecBase
 
 _LOGGER = logging.getLogger(__name__)
 
+MIN_CHARGE_CURRENT = 6  # IEC 61851 minimum charging current (A)
+
 
 class ZaptecNumber[ZaptecObjectT: ZaptecBase](ZaptecBaseEntity[ZaptecObjectT], NumberEntity):
     """Base class for Zaptec number entities."""
@@ -104,14 +106,27 @@ class ZaptecSettingNumber(ZaptecNumber[Charger]):
     async def async_set_native_value(self, value: float) -> None:
         """Update to Zaptec."""
         self._log_number(value)
-        if not self.entity_description.setting:
+        setting = self.entity_description.setting
+        if not setting:
             raise HomeAssistantError(f"No setting for {self.__class__.__qualname__}.{self.key}")
+
+        if setting == "minChargeCurrent":
+            max_current = self.zaptec_obj.get("charger_max_current")
+            if isinstance(max_current, (int, float)) and value > max_current:
+                raise HomeAssistantError(
+                    f"Min current {value} cannot be higher than max current {max_current}"
+                )
+        elif setting == "maxChargeCurrent":
+            min_current = self.zaptec_obj.get("charger_min_current")
+            if isinstance(min_current, (int, float)) and value < min_current:
+                raise HomeAssistantError(
+                    f"Max current {value} cannot be lower than min current {min_current}"
+                )
+
         try:
-            await self.zaptec_obj.set_settings({self.entity_description.setting: value})
+            await self.zaptec_obj.set_settings({setting: value})
         except Exception as exc:
-            raise HomeAssistantError(
-                f"Setting {self.entity_description.setting} to {value} failed"
-            ) from exc
+            raise HomeAssistantError(f"Setting {setting} to {value} failed") from exc
 
         await self.trigger_poll()
 
@@ -176,7 +191,7 @@ CHARGER_ENTITIES: list[ZaptecEntityDescription] = [
         translation_key="charger_min_current",
         device_class=NumberDeviceClass.CURRENT,
         entity_category=EntityCategory.CONFIG,
-        native_min_value=0,
+        native_min_value=MIN_CHARGE_CURRENT,
         native_max_value=32,
         icon="mdi:current-ac",
         native_unit_of_measurement=const.UnitOfElectricCurrent.AMPERE,

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,42 @@
+"""Tests for number.py."""
+
+import pytest
+
+from custom_components.zaptec.manager import ZaptecEntityDescription
+from custom_components.zaptec.number import (
+    CHARGER_ENTITIES,
+    INSTALLATION_ENTITIES,
+    MIN_CHARGE_CURRENT,
+    ZapNumberEntityDescription,
+)
+
+
+def _find(descriptions: list[ZaptecEntityDescription], key: str) -> ZapNumberEntityDescription:
+    """Return the entity description with the given key."""
+    return next(d for d in descriptions if d.key == key)
+
+
+@pytest.mark.parametrize(
+    ("descriptions", "key", "expected_min"),
+    [
+        pytest.param(
+            CHARGER_ENTITIES, "charger_min_current", MIN_CHARGE_CURRENT, id="charger_min_current"
+        ),
+        # 0 holds the charger off rather than requesting a charging current.
+        pytest.param(INSTALLATION_ENTITIES, "available_current", 0, id="available_current"),
+        # Zaptec documents 0 as the way to force 3-phase charging.
+        pytest.param(
+            INSTALLATION_ENTITIES,
+            "three_to_one_phase_switch_current",
+            0,
+            id="phase_switch_current",
+        ),
+        # Constrained relationally against charger_min_current, not by a static floor.
+        pytest.param(CHARGER_ENTITIES, "charger_max_current", 0, id="charger_max_current"),
+    ],
+)
+def test_native_min_value(
+    descriptions: list[ZaptecEntityDescription], key: str, expected_min: float
+) -> None:
+    """Only charger_min_current declares the 6A floor."""
+    assert _find(descriptions, key).native_min_value == expected_min


### PR DESCRIPTION
The Zaptec API accepts `ChargerMinCurrent = 0`, but the portal then rejects any
later settings change for that charger (#289). This raises the entity minimum to
the IEC 61851 floor of 6A, and rejects setting `charger_max_current` below
`charger_min_current` and vice versa.

`AvailableCurrent` and `ThreeToOnePhaseSwitchCurrent` keep a 0 minimum, contrary
to the blanket ">= 6A" advice in the issue thread. 0 is not a charging current
for either: it forces 3-phase charging on the latter (per Zaptec's own docs, as
raised in the thread), and is a regularly used way to hold the charger off on the
former — flooring it would break existing automations that stop charging that way.

Behavior change worth noting: a charger currently reporting a minimum below 6A
will show that value as out of range until it is raised, and `number.set_value`
calls below 6A now fail.

Tests cover the declared minimums only. The max/min check needs entity-level
tests, and I'd rather write those against the harness from #414 than hand-rolled
mocks — happy to add a commit with them once #414 has merged, if you'd like.